### PR TITLE
Provide a way to set an initial default input text

### DIFF
--- a/examples/text_options.rs
+++ b/examples/text_options.rs
@@ -11,6 +11,7 @@ fn main() {
 
     let _input = Text {
         message: "How are you feeling?",
+        initial_value: None,
         default: None,
         placeholder: Some("Good"),
         help_message: None,


### PR DESCRIPTION
Hello, I'm looking on a cli search engine and I was looking for a way to put a default text in the search bar but that was not possible.
Here is an implementation of this feature.

And here is an example of how I want to use it:
https://github.com/irevoire/mieli/commit/ccaae2e13f2b18d93316da795efc735ad9815e08

And here is a video of what it would allow me to do:
[![asciicast](https://asciinema.org/a/XSCobUuDGa8MTPHq9fC3cwRKD.svg)](https://asciinema.org/a/XSCobUuDGa8MTPHq9fC3cwRKD)