### PR TITLE
Fix the trailing semicolon in macro warning

### DIFF
--- a/src/prompts/prompt_common.rs
+++ b/src/prompts/prompt_common.rs
@@ -9,7 +9,7 @@ macro_rules! cancel_prompt {
 
 macro_rules! interrupt_prompt {
     () => {
-        return Err(InquireError::OperationInterrupted);
+        return Err(InquireError::OperationInterrupted)
     };
 }
 


### PR DESCRIPTION
Currently, we have this warning on main with rust nightly:
```
warning: trailing semicolon in macro used in expression position
   --> src/prompts/prompt_common.rs:12:55
    |
12  |         return Err(InquireError::OperationInterrupted);
    |                                                       ^
    |
   ::: src/prompts/text.rs:414:35
    |
414 |                 Key::Interrupt => interrupt_prompt!(),
    |                                   ------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `interrupt_prompt` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Here is the fix. Obviously, it causes no problem with rust stable or beta :smile:!