### PR TITLE
Fix the link to Suggester in the struct.Text docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 The docs contain more through explanations and full-featured examples.
 
+### Fixes
+
+- Fix a broken link in the `struct.Text` documentation.
+
 ## [0.2.1] - 2021-10-01
 
 ### Features

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -45,7 +45,7 @@ const DEFAULT_HELP_MESSAGE: &str = "↑↓ to move, tab to auto-complete, enter 
 ///
 /// With `Text` inputs, it is also possible to set-up an auto-completion system to provide a better UX when necessary.
 ///
-/// You can set-up a custom [`Suggester`](crate::config::Suggester) function, which receives the current input as the only argument and should return a vector of strings, the suggested values.
+/// You can set-up a custom [`Suggester`](crate::type_aliases::Suggester) function, which receives the current input as the only argument and should return a vector of strings, the suggested values.
 ///
 /// The user is then able to select one of them by moving up and down the list, possibly further modifying a selected suggestion.
 ///


### PR DESCRIPTION
This link is broken in the currently published version of the docs; see https://docs.rs/inquire/0.2.1/inquire/struct.Text.html#autocomplete