### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/terminal/termion.rs
+++ b/src/terminal/termion.rs
@@ -42,7 +42,7 @@ impl<'a> TermionTerminal<'a> {
             .into_raw_mode()
             .map_err(|e| match e.raw_os_error() {
                 Some(25) | Some(6) => InquireError::NotTTY,
-                _ => std::io::Error::from(e).into(),
+                _ => e.into(),
             });
 
         Ok(Self {
@@ -168,10 +168,10 @@ impl<'a> Terminal for TermionTerminal<'a> {
 
         self.write(&val.content)?;
 
-        if let Some(_) = val.style.fg.as_ref() {
+        if val.style.fg.as_ref().is_some() {
             self.reset_fg_color()?;
         }
-        if let Some(_) = val.style.bg.as_ref() {
+        if val.style.bg.as_ref().is_some() {
             self.reset_bg_color()?;
         }
         if !val.style.att.is_empty() {

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -68,16 +68,10 @@ pub trait PasswordBackend: CommonBackend {
     fn render_prompt_with_full_input(&mut self, prompt: &str, cur_input: &Input) -> Result<()>;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Position {
     pub row: u16,
     pub col: u16,
-}
-
-impl Default for Position {
-    fn default() -> Self {
-        Self { row: 0, col: 0 }
-    }
 }
 
 pub struct Backend<T>
@@ -574,6 +568,8 @@ pub mod date {
 
     pub trait DateSelectBackend: CommonBackend {
         fn render_calendar_prompt(&mut self, prompt: &str) -> Result<()>;
+
+        #[allow(clippy::too_many_arguments)]
         fn render_calendar(
             &mut self,
             month: chrono::Month,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,6 +64,8 @@ where
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::bool_assert_comparison)]
+
     use crate::{
         list_option::ListOption,
         utils::{int_log10, paginate},


### PR DESCRIPTION
Fix the latest clippy warning reported with Rust 1.58.
