### PR TITLE
Adding text autocomplete feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Unsuccessful executions return a `CustomUserError` type, which is an alias for `Box<dyn std::error::Error + Send + Sync + 'static>`. 
 - **(Breaking Change)** The function signature for suggesters has also been changed to allow fallible executions. The return type in successful executions continues to be `Vec<String>`, while `CustomUserError` is used with errors. The docs contain more thorough explanations and full-featured examples.
 - Added `answered_prompt_prefix` configuration on `RenderConfig`, allowing users to set custom prefixes (e.g. a check mark) to prompts that have already been answered. Cheers to @href for the suggestion! [#44](https://github.com/mikaelmello/inquire/pull/44)
+- Added `Completer` parameter on `Text` prompt to handle `tab` key events. It takes the current input and return an optional suggestion. If any, the prompter will replace the current input with the received suggestion. `Completer` is an alias for `&'a dyn Fn(&str) -> Result<Option<String>, CustomUserError>`.
 
 ### Fixes
 

--- a/KEY_BINDINGS.md
+++ b/KEY_BINDINGS.md
@@ -45,6 +45,7 @@ These key bindings may be used in [`Text`] prompts.
 | <kbd>down</kbd>      | When suggestions are displayed, move cursor one row down.     |
 | <kbd>page up</kbd>   | When suggestions are displayed, move cursor one page up.      |
 | <kbd>page down</kbd> | When suggestions are displayed, move cursor one page down.    |
+| <kbd>tab</kbd>       | Replace current input with the resulting suggestion if any.   |
 | others               | See [Text Input](#text-input) and [All Prompts](#all-prompts) |
 
 ## Select Prompts

--- a/examples/autocomplete_path.rs
+++ b/examples/autocomplete_path.rs
@@ -1,0 +1,84 @@
+use inquire::{CustomUserError, Text};
+
+fn main() {
+    let ans = Text::new("Profil picture:")
+        .with_suggester(&suggest_file_paths)
+        .with_completer(&complete_file_path)
+        .prompt();
+
+    match ans {
+        Ok(path) => println!("Path: {path}"),
+        Err(error) => println!("Error with questionnaire, try again later: {error:?}"),
+    }
+}
+
+fn suggest_file_paths(input: &str) -> Result<Vec<String>, CustomUserError> {
+    Ok(list_paths(input)?)
+}
+
+fn complete_file_path(input: &str) -> Result<Option<String>, CustomUserError> {
+    // Implementation from https://rosettacode.org/wiki/Longest_common_prefix#Rust
+    fn longest_common_prefix<T: AsRef<[u8]>>(list: &[T]) -> Option<Vec<u8>> {
+        if list.is_empty() {
+            return None;
+        }
+        let mut ret = Vec::new();
+        let mut i = 0;
+        loop {
+            let mut c = None;
+            for word in list {
+                let word = word.as_ref();
+                if i == word.len() {
+                    return Some(ret);
+                }
+                match c {
+                    None => {
+                        c = Some(word[i]);
+                    }
+                    Some(letter) if letter != word[i] => return Some(ret),
+                    _ => continue,
+                }
+            }
+            if let Some(letter) = c {
+                ret.push(letter);
+            }
+            i += 1;
+        }
+    }
+
+    Ok(longest_common_prefix(&list_paths(input)?)
+        .map(|bytes| String::from_utf8_lossy(&bytes).to_string()))
+}
+
+fn list_paths(root: &str) -> std::io::Result<Vec<String>> {
+    let mut suggestions = vec![];
+
+    let mut input_path = std::path::PathBuf::from(root);
+    if let Some(parent) = input_path.parent() {
+        if !input_path.exists() || !input_path.is_dir() || !root.ends_with('/') {
+            input_path = parent.to_path_buf();
+        }
+    }
+    if root.is_empty() {
+        input_path = std::env::current_dir()?;
+    }
+    if !input_path.exists() {
+        return Ok(vec![]);
+    }
+
+    for entry in std::fs::read_dir(input_path)? {
+        let path = entry?.path();
+        let path_str = path.to_string_lossy();
+
+        if path_str.starts_with(root) {
+            let path = if path.is_dir() {
+                format!("{}/", path_str)
+            } else {
+                path_str.to_string()
+            };
+            suggestions.push(path);
+        }
+    }
+
+    Ok(suggestions)
+}

--- a/examples/autocomplete_path.rs
+++ b/examples/autocomplete_path.rs
@@ -1,7 +1,7 @@
 use inquire::{CustomUserError, Text};
 
 fn main() {
-    let ans = Text::new("Profil picture:")
+    let ans = Text::new("Profile picture:")
         .with_suggester(&suggest_file_paths)
         .with_completer(&complete_file_path)
         .prompt();

--- a/examples/autocomplete_path.rs
+++ b/examples/autocomplete_path.rs
@@ -7,8 +7,8 @@ fn main() {
         .prompt();
 
     match ans {
-        Ok(path) => println!("Path: {path}"),
-        Err(error) => println!("Error with questionnaire, try again later: {error:?}"),
+        Ok(path) => println!("Path: {}", path),
+        Err(error) => println!("Error with questionnaire, try again later: {:?}", error),
     }
 }
 

--- a/examples/text_options.rs
+++ b/examples/text_options.rs
@@ -19,6 +19,7 @@ fn main() {
         validators: Vec::new(),
         page_size: Text::DEFAULT_PAGE_SIZE,
         suggester: None,
+        completer: None,
         render_config: RenderConfig::default(),
     }
     .prompt()

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -42,3 +42,8 @@ pub type Filter<'a, T> = &'a dyn Fn(&str, &T, &str, usize) -> bool;
 /// The function receives the current input and should return a collection of strings
 /// containing the suggestions to be made to the user.
 pub type Suggester<'a> = &'a dyn Fn(&str) -> Result<Vec<String>, CustomUserError>;
+
+/// Type alias to represent the function used to retreive an optional autocompletion suggestion.
+/// The function receives the current input and should return the suggestion (if any)
+/// that will replace the current input.
+pub type Completer<'a> = &'a dyn Fn(&str) -> Result<Option<String>, CustomUserError>;

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -43,7 +43,7 @@ pub type Filter<'a, T> = &'a dyn Fn(&str, &T, &str, usize) -> bool;
 /// containing the suggestions to be made to the user.
 pub type Suggester<'a> = &'a dyn Fn(&str) -> Result<Vec<String>, CustomUserError>;
 
-/// Type alias to represent the function used to retreive an optional autocompletion suggestion.
+/// Type alias to represent the function used to retrieve an optional autocompletion suggestion.
 /// The function receives the current input and should return the suggestion (if any)
 /// that will replace the current input.
 pub type Completer<'a> = &'a dyn Fn(&str) -> Result<Option<String>, CustomUserError>;


### PR DESCRIPTION
Proposal to fix #47 

Adding a new `type_alias`: `Completer` that take the current input and return an optional suggestion (`Option<String>`). If any, the `Text` prompter will replace the current input with the received suggestion.

Adding new `autocomplete_path` example to demonstrate this new feature. This example is a simple `path` completer.