### PR TITLE
Update crossterm to v0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-crossterm = { version = "0.23", optional = true }
+crossterm = { version = "0.24", optional = true }
 termion = { version = "1.5", optional = true }
 console = { version = "0.15", optional = true, features = ["windows-console-colors"] }
 


### PR DESCRIPTION
Updating `crossterm` again, as they made a new breaking release in the meantime. So we're on the latest version for the next release of this crate.