### PR TITLE
Add with_starting_date function for DateSelect

### DIFF
--- a/examples/date.rs
+++ b/examples/date.rs
@@ -6,6 +6,7 @@ fn main() {
     custom_type_parsed_date_prompt();
     date_select_misc_options();
     date_select_with_validation();
+    date_select_with_starting_date();
 }
 
 fn date_select_default() {
@@ -75,5 +76,23 @@ fn date_select_with_validation() {
         Ok(_) => println!("No flights available for this date."),
         Err(_) => println!("There was an error in the system."),
     }
+    println!();
+}
+
+fn date_select_with_starting_date() {
+    println!("-------> DateSelect with yesterday as initial value");
+    println!();
+
+    DateSelect::new("Check-in date:")
+        .with_starting_date(
+            chrono::Local::now()
+                .date()
+                .naive_local()
+                .pred_opt()
+                .unwrap(),
+        )
+        .prompt()
+        .unwrap();
+    println!("We will be expecting you!");
     println!();
 }

--- a/src/prompts/dateselect.rs
+++ b/src/prompts/dateselect.rs
@@ -177,6 +177,12 @@ impl<'a> DateSelect<'a> {
         self
     }
 
+    /// Sets the starting date.
+    pub fn with_starting_date(mut self, starting_date: NaiveDate) -> Self {
+        self.starting_date = starting_date;
+        self
+    }
+
     /// Adds a validator to the collection of validators. You might want to use this feature
     /// in case you need to limit the user to specific choices, such as not allowing weekends.
     ///


### PR DESCRIPTION
I needed this function myself, and apparently it doesn't currently exist.

I don't see why you wouldn't want this function, but if there's some reason for it, feel free to close the PR.

Even though the change is trivial, I added an example to sanity check that everything was still working, if you don't want the extra example, let me know and I'll update the PR.