### PR TITLE
Add support for styling currently selected option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+- Selected option can now be styled independently of other options through `RenderConfig::with_selected_option()`
 
 ## [0.5.3] - 2023-01-09
 

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -225,9 +225,11 @@ where
     fn print_option_value<D: Display>(
         &mut self,
         option: &ListOption<D>,
-        is_selected: bool,
+        idx: usize,
+        page: &Page<ListOption<D>>,
     ) -> Result<()> {
-        let style_sheet = if is_selected && !self.render_config.selected_option.is_empty() {
+        let style_sheet = if idx == page.selection && !self.render_config.selected_option.is_empty()
+        {
             self.render_config.selected_option
         } else {
             self.render_config.option
@@ -459,8 +461,7 @@ where
             self.print_option_prefix(idx, &page)?;
 
             self.terminal.write(" ")?;
-
-            self.print_option_value(option, idx == page.selection)?;
+            self.print_option_value(option, idx, &page)?;
 
             self.new_line()?;
         }
@@ -508,7 +509,7 @@ where
                 self.terminal.write(" ")?;
             }
 
-            self.print_option_value(option, idx == page.selection)?;
+            self.print_option_value(option, idx, &page)?;
 
             self.new_line()?;
         }
@@ -551,7 +552,7 @@ where
 
             self.terminal.write(" ")?;
 
-            self.print_option_value(option, idx == page.selection)?;
+            self.print_option_value(option, idx, &page)?;
 
             self.new_line()?;
         }

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -228,9 +228,9 @@ where
         page: &Page<ListOption<D>>,
     ) -> Result<()> {
         let style_sheet = if page.content[page.selection].index == option.index
-            && !self.render_config.selected_option.is_empty()
+            && self.render_config.selected_option.is_some()
         {
-            self.render_config.selected_option
+            self.render_config.selected_option.unwrap()
         } else {
             self.render_config.option
         };

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt::Display, io::Result};
+use std::{collections::BTreeSet, fmt::Display, io::Result, ops::Index};
 
 use unicode_width::UnicodeWidthChar;
 
@@ -225,10 +225,10 @@ where
     fn print_option_value<D: Display>(
         &mut self,
         option: &ListOption<D>,
-        idx: usize,
         page: &Page<ListOption<D>>,
     ) -> Result<()> {
-        let style_sheet = if idx == page.selection && !self.render_config.selected_option.is_empty()
+        let style_sheet = if page.content[page.selection].index == option.index
+            && !self.render_config.selected_option.is_empty()
         {
             self.render_config.selected_option
         } else {
@@ -461,7 +461,7 @@ where
             self.print_option_prefix(idx, &page)?;
 
             self.terminal.write(" ")?;
-            self.print_option_value(option, idx, &page)?;
+            self.print_option_value(option, &page)?;
 
             self.new_line()?;
         }
@@ -509,7 +509,7 @@ where
                 self.terminal.write(" ")?;
             }
 
-            self.print_option_value(option, idx, &page)?;
+            self.print_option_value(option, &page)?;
 
             self.new_line()?;
         }
@@ -552,7 +552,7 @@ where
 
             self.terminal.write(" ")?;
 
-            self.print_option_value(option, idx, &page)?;
+            self.print_option_value(option, &page)?;
 
             self.new_line()?;
         }

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt::Display, io::Result, ops::Index};
+use std::{collections::BTreeSet, fmt::Display, io::Result};
 
 use unicode_width::UnicodeWidthChar;
 

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -222,9 +222,19 @@ where
         self.terminal.write_styled(&x)
     }
 
-    fn print_option_value<D: Display>(&mut self, option: &ListOption<D>) -> Result<()> {
+    fn print_option_value<D: Display>(
+        &mut self,
+        option: &ListOption<D>,
+        is_selected: bool,
+    ) -> Result<()> {
+        let style_sheet = if is_selected && !self.render_config.selected_option.is_empty() {
+            self.render_config.selected_option
+        } else {
+            self.render_config.option
+        };
+
         self.terminal
-            .write_styled(&Styled::new(&option.value).with_style_sheet(self.render_config.option))
+            .write_styled(&Styled::new(&option.value).with_style_sheet(style_sheet))
     }
 
     fn print_option_index_prefix(&mut self, index: usize, max_index: usize) -> Option<Result<()>> {
@@ -450,7 +460,7 @@ where
 
             self.terminal.write(" ")?;
 
-            self.print_option_value(option)?;
+            self.print_option_value(option, idx == page.selection)?;
 
             self.new_line()?;
         }
@@ -498,7 +508,7 @@ where
                 self.terminal.write(" ")?;
             }
 
-            self.print_option_value(option)?;
+            self.print_option_value(option, idx == page.selection)?;
 
             self.new_line()?;
         }
@@ -541,7 +551,7 @@ where
 
             self.terminal.write(" ")?;
 
-            self.print_option_value(option)?;
+            self.print_option_value(option, idx == page.selection)?;
 
             self.new_line()?;
         }

--- a/src/ui/render_config.rs
+++ b/src/ui/render_config.rs
@@ -127,6 +127,12 @@ pub struct RenderConfig {
     /// a separator from the prefix.
     pub option: StyleSheet,
 
+    /// Style sheet for the option that is currently selected.
+    ///
+    /// Note: a non-styled space character is added before the option value as
+    /// a separator from the prefix.
+    pub selected_option: StyleSheet,
+
     /// Render configuration for calendar
 
     #[cfg(feature = "date")]
@@ -163,6 +169,7 @@ impl RenderConfig {
             unselected_checkbox: Styled::new("[ ]"),
             option_index_prefix: IndexPrefix::None,
             option: StyleSheet::empty(),
+            selected_option: StyleSheet::empty(),
 
             #[cfg(feature = "date")]
             calendar: calendar::CalendarRenderConfig::empty(),
@@ -193,6 +200,7 @@ impl RenderConfig {
             unselected_checkbox: Styled::new("[ ]"),
             option_index_prefix: IndexPrefix::None,
             option: StyleSheet::empty(),
+            selected_option: StyleSheet::empty(),
 
             #[cfg(feature = "date")]
             calendar: calendar::CalendarRenderConfig::default_colored(),
@@ -280,6 +288,12 @@ impl RenderConfig {
     /// Sets the style sheet for option values.
     pub fn with_option(mut self, option: StyleSheet) -> Self {
         self.option = option;
+        self
+    }
+
+    /// Sets the style sheet for currently selected option.
+    pub fn with_selected_option(mut self, selected_option: StyleSheet) -> Self {
+        self.selected_option = selected_option;
         self
     }
 

--- a/src/ui/render_config.rs
+++ b/src/ui/render_config.rs
@@ -127,7 +127,8 @@ pub struct RenderConfig {
     /// a separator from the prefix.
     pub option: StyleSheet,
 
-    /// Style sheet for the option that is currently selected. If the value is None, it will fallback to `option`.
+    /// Style sheet for the option that is currently selected. If the value is
+    /// None, it will fall back to `option`.
     ///
     /// Note: a non-styled space character is added before the option value as
     /// a separator from the prefix.

--- a/src/ui/render_config.rs
+++ b/src/ui/render_config.rs
@@ -127,16 +127,16 @@ pub struct RenderConfig {
     /// a separator from the prefix.
     pub option: StyleSheet,
 
-    /// Style sheet for the option that is currently selected.
+    /// Style sheet for the option that is currently selected. If the value is None, it will fallback to `option`.
     ///
     /// Note: a non-styled space character is added before the option value as
     /// a separator from the prefix.
-    pub selected_option: StyleSheet,
+    pub selected_option: Option<StyleSheet>,
 
     /// Render configuration for calendar
 
     #[cfg(feature = "date")]
-    /// Render configuration for date prompts.
+    /// Render configuration for date prompts`
     pub calendar: calendar::CalendarRenderConfig,
 
     /// Style sheet of the hint in editor prompts.
@@ -169,7 +169,7 @@ impl RenderConfig {
             unselected_checkbox: Styled::new("[ ]"),
             option_index_prefix: IndexPrefix::None,
             option: StyleSheet::empty(),
-            selected_option: StyleSheet::empty(),
+            selected_option: None,
 
             #[cfg(feature = "date")]
             calendar: calendar::CalendarRenderConfig::empty(),
@@ -200,7 +200,7 @@ impl RenderConfig {
             unselected_checkbox: Styled::new("[ ]"),
             option_index_prefix: IndexPrefix::None,
             option: StyleSheet::empty(),
-            selected_option: StyleSheet::empty(),
+            selected_option: None,
 
             #[cfg(feature = "date")]
             calendar: calendar::CalendarRenderConfig::default_colored(),
@@ -292,7 +292,7 @@ impl RenderConfig {
     }
 
     /// Sets the style sheet for currently selected option.
-    pub fn with_selected_option(mut self, selected_option: StyleSheet) -> Self {
+    pub fn with_selected_option(mut self, selected_option: Option<StyleSheet>) -> Self {
         self.selected_option = selected_option;
         self
     }


### PR DESCRIPTION
Selected option can now be styled separately from other options. If user does not define styling for selected option, `RenderConfig`'s `option` property will be used.

This is implemented via simple `is_selected` flag in `print_option_value()` since the implementation is simple and it doesn't break public API. Please let me know if there is a solution which follows projects style guide more closely :)

Closes https://github.com/mikaelmello/inquire/issues/85 