### PR TITLE
replace `stdout` with `stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+### Breaking Changes
+
+- Output dialogs on `stderr` instead of `stdout` [#89](https://github.com/mikaelmello/inquire/pull/89)
+  - `stdout` is usually used to carry (parseable) data, while other information (logs, dlailogs, etc.) got to `stderr`. This makes `inquire` compatible with such systems.
 
 ## [0.5.3] - 2023-01-09
 

--- a/src/terminal/console.rs
+++ b/src/terminal/console.rs
@@ -15,7 +15,7 @@ impl ConsoleTerminal {
     #[allow(unused)]
     pub fn new() -> Self {
         Self {
-            term: Term::stdout(),
+            term: Term::stderr(),
             in_memory_content: String::with_capacity(INITIAL_IN_MEMORY_CAPACITY),
         }
     }

--- a/src/terminal/crossterm.rs
+++ b/src/terminal/crossterm.rs
@@ -1,4 +1,4 @@
-use std::io::{stdout, Result, Stdout, Write};
+use std::io::{stderr, Result, Stderr, Write};
 
 use crossterm::{
     cursor,
@@ -18,7 +18,7 @@ use super::{Terminal, INITIAL_IN_MEMORY_CAPACITY};
 
 enum IO<'a> {
     Std {
-        w: Stdout,
+        w: Stderr,
     },
     #[allow(unused)]
     Custom {
@@ -40,7 +40,7 @@ impl<'a> CrosstermTerminal<'a> {
         })?;
 
         Ok(Self {
-            io: IO::Std { w: stdout() },
+            io: IO::Std { w: stderr() },
             in_memory_content: String::with_capacity(INITIAL_IN_MEMORY_CAPACITY),
         })
     }

--- a/src/terminal/termion.rs
+++ b/src/terminal/termion.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::io::{stdin, stdout, Result, Stdin, Stdout, Write};
+use std::io::{stdin, stderr, Result, Stdin, Stderr, Write};
 
 use termion::{
     color::{self, Color},
@@ -21,7 +21,7 @@ enum IO<'a> {
     #[allow(unused)]
     Std {
         r: Keys<Stdin>,
-        w: RawTerminal<Stdout>,
+        w: RawTerminal<Stderr>,
     },
     #[allow(unused)]
     Custom {
@@ -38,7 +38,7 @@ pub struct TermionTerminal<'a> {
 impl<'a> TermionTerminal<'a> {
     #[allow(unused)]
     pub fn new() -> InquireResult<Self> {
-        let raw_mode = stdout()
+        let raw_mode = stderr()
             .into_raw_mode()
             .map_err(|e| match e.raw_os_error() {
                 Some(25) | Some(6) => InquireError::NotTTY,


### PR DESCRIPTION
In many cases its desirable to have non data output on `stderr` rather than `stdout`.
Would you mind accepting this change or make the output configurable?