### PR TITLE
Allow lifetime customization of RenderConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-### Breaking Changes
-
 - Allow lifetime customization of RenderConfig. [#101](https://github.com/mikaelmello/inquire/pull/101). Thanks to @arturfast for the suggestion [#95](https://github.com/mikaelmello/inquire/issues/95).
 
 ## [0.6.1] - 2023-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
+### Breaking Changes
+
+- Allow lifetime customization of RenderConfig. [#101](https://github.com/mikaelmello/inquire/pull/101). Thanks to @arturfast for the suggestion [#95](https://github.com/mikaelmello/inquire/issues/95).
+
 ## [0.6.1] - 2023-04-08
 
 - Fix incorrect highlighting of lists when filtered. [#110](https://github.com/mikaelmello/inquire/pull/110). Thanks to [@prime31](https://github.com/prime31) for reporting on [#106](https://github.com/mikaelmello/inquire/issues/106).

--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -26,7 +26,7 @@ fn main() -> InquireResult<()> {
     Ok(())
 }
 
-fn description_render_config() -> RenderConfig {
+fn description_render_config() -> RenderConfig<'static> {
     RenderConfig::default()
         .with_canceled_prompt_indicator(Styled::new("<skipped>").with_fg(Color::DarkYellow))
 }

--- a/examples/render_config.rs
+++ b/examples/render_config.rs
@@ -149,7 +149,7 @@ fn get_existing_payees() -> &'static [&'static str] {
     ]
 }
 
-fn get_render_config() -> RenderConfig {
+fn get_render_config() -> RenderConfig<'static> {
     let mut render_config = RenderConfig::default();
     render_config.prompt_prefix = Styled::new("$").with_fg(Color::LightRed);
     render_config.highlighted_option_prefix = Styled::new("➠").with_fg(Color::LightYellow);

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,17 +7,17 @@ use lazy_static::lazy_static;
 use crate::ui::RenderConfig;
 
 lazy_static! {
-    static ref GLOBAL_RENDER_CONFIGURATION: Mutex<RenderConfig> =
+    static ref GLOBAL_RENDER_CONFIGURATION: Mutex<RenderConfig<'static>> =
         Mutex::new(RenderConfig::default());
 }
 
-pub fn get_configuration() -> RenderConfig {
+pub fn get_configuration() -> RenderConfig<'static> {
     *GLOBAL_RENDER_CONFIGURATION.lock().unwrap()
 }
 
 /// Acquires a write lock to the global RenderConfig object
 /// and updates the inner value with the provided argument.
-pub fn set_global_render_config(config: RenderConfig) {
+pub fn set_global_render_config(config: RenderConfig<'static>) {
     let mut guard = GLOBAL_RENDER_CONFIGURATION.lock().unwrap();
     *guard = config;
 }

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -86,7 +86,7 @@ pub struct Confirm<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a> Confirm<'a> {
@@ -172,7 +172,7 @@ impl<'a> Confirm<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }
@@ -204,7 +204,7 @@ impl<'a> Confirm<'a> {
 
     pub(crate) fn prompt_with_backend<T: Terminal>(
         self,
-        backend: &mut Backend<T>,
+        backend: &mut Backend<'a, T>,
     ) -> InquireResult<bool> {
         CustomType::from(self).prompt_with_backend(backend)
     }

--- a/src/prompts/custom_type.rs
+++ b/src/prompts/custom_type.rs
@@ -109,7 +109,7 @@ pub struct CustomType<'a, T> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a, T> CustomType<'a, T>
@@ -228,7 +228,7 @@ where
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/prompts/dateselect.rs
+++ b/src/prompts/dateselect.rs
@@ -99,7 +99,7 @@ pub struct DateSelect<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a> DateSelect<'a> {
@@ -238,7 +238,7 @@ impl<'a> DateSelect<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }
@@ -270,7 +270,7 @@ impl<'a> DateSelect<'a> {
 
     pub(crate) fn prompt_with_backend<T: Terminal>(
         self,
-        backend: &mut Backend<T>,
+        backend: &mut Backend<'a, T>,
     ) -> InquireResult<NaiveDate> {
         DateSelectPrompt::new(self)?.prompt(backend)
     }

--- a/src/prompts/editor.rs
+++ b/src/prompts/editor.rs
@@ -85,7 +85,7 @@ pub struct Editor<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a> Editor<'a> {
@@ -195,7 +195,7 @@ impl<'a> Editor<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/prompts/multiselect.rs
+++ b/src/prompts/multiselect.rs
@@ -90,7 +90,7 @@ pub struct MultiSelect<'a, T> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a, T> MultiSelect<'a, T>
@@ -262,7 +262,7 @@ where
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -127,7 +127,7 @@ pub struct Password<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a> Password<'a> {
@@ -251,7 +251,7 @@ impl<'a> Password<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -89,7 +89,7 @@ pub struct Select<'a, T> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a, T> Select<'a, T>
@@ -218,7 +218,7 @@ where
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -112,7 +112,7 @@ pub struct Text<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub render_config: RenderConfig,
+    pub render_config: RenderConfig<'a>,
 }
 
 impl<'a> Text<'a> {
@@ -239,7 +239,7 @@ impl<'a> Text<'a> {
     /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still suport NO_COLOR, you will have to do this on your end.
-    pub fn with_render_config(mut self, render_config: RenderConfig) -> Self {
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
         self
     }

--- a/src/ui/backend.rs
+++ b/src/ui/backend.rs
@@ -74,7 +74,7 @@ pub struct Position {
     pub col: u16,
 }
 
-pub struct Backend<T>
+pub struct Backend<'a, T>
 where
     T: Terminal,
 {
@@ -85,14 +85,14 @@ where
     show_cursor: bool,
     terminal: T,
     terminal_size: TerminalSize,
-    render_config: RenderConfig,
+    render_config: RenderConfig<'a>,
 }
 
-impl<T> Backend<T>
+impl<'a, T> Backend<'a, T>
 where
     T: Terminal,
 {
-    pub fn new(terminal: T, render_config: RenderConfig) -> Result<Self> {
+    pub fn new(terminal: T, render_config: RenderConfig<'a>) -> Result<Self> {
         let terminal_size = terminal.get_size().unwrap_or(TerminalSize {
             width: 1000,
             height: 1000,
@@ -348,7 +348,7 @@ where
     }
 }
 
-impl<T> CommonBackend for Backend<T>
+impl<'a, T> CommonBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -445,7 +445,7 @@ where
     }
 }
 
-impl<T> TextBackend for Backend<T>
+impl<'a, T> TextBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -473,7 +473,7 @@ where
 }
 
 #[cfg(feature = "editor")]
-impl<T> EditorBackend for Backend<T>
+impl<'a, T> EditorBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -492,7 +492,7 @@ where
     }
 }
 
-impl<T> SelectBackend for Backend<T>
+impl<'a, T> SelectBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -520,7 +520,7 @@ where
     }
 }
 
-impl<T> MultiSelectBackend for Backend<T>
+impl<'a, T> MultiSelectBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -592,7 +592,7 @@ pub mod date {
         ) -> Result<()>;
     }
 
-    impl<T> DateSelectBackend for Backend<T>
+    impl<'a, T> DateSelectBackend for Backend<'a, T>
     where
         T: Terminal,
     {
@@ -716,7 +716,7 @@ pub mod date {
     }
 }
 
-impl<T> CustomTypeBackend for Backend<T>
+impl<'a, T> CustomTypeBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -730,7 +730,7 @@ where
     }
 }
 
-impl<T> PasswordBackend for Backend<T>
+impl<'a, T> PasswordBackend for Backend<'a, T>
 where
     T: Terminal,
 {
@@ -755,7 +755,7 @@ where
     }
 }
 
-impl<T> Drop for Backend<T>
+impl<'a, T> Drop for Backend<'a, T>
 where
     T: Terminal,
 {

--- a/src/ui/render_config.rs
+++ b/src/ui/render_config.rs
@@ -20,18 +20,18 @@ use super::{Color, StyleSheet, Styled};
 /// let mine = default.with_prompt_prefix(prompt_prefix);
 /// ```
 #[derive(Copy, Clone, Debug)]
-pub struct RenderConfig {
+pub struct RenderConfig<'a> {
     /// Prefix added before prompts.
     ///
     /// Note: a space character will be added to separate the prefix
     /// and the prompt message.
-    pub prompt_prefix: Styled<&'static str>,
+    pub prompt_prefix: Styled<&'a str>,
 
     /// Prefix added before answered prompts.
     ///
     /// Note: a space character will be added to separate the prefix
     /// and the prompt message.
-    pub answered_prompt_prefix: Styled<&'static str>,
+    pub answered_prompt_prefix: Styled<&'a str>,
 
     /// Style of the prompt message, applicable to all prompt types.
     pub prompt: StyleSheet,
@@ -79,44 +79,44 @@ pub struct RenderConfig {
     ///
     /// Note: a non-styled space character is added before the indicator as
     /// a separator from the prompt message.
-    pub canceled_prompt_indicator: Styled<&'static str>,
+    pub canceled_prompt_indicator: Styled<&'a str>,
 
     /// Render configuration for error messages.
-    pub error_message: ErrorMessageRenderConfig,
+    pub error_message: ErrorMessageRenderConfig<'a>,
 
     /// Prefix for the current highlighted option.
     ///
     /// Note: a space character will be added to separate the prefix
     /// and the option value or the checkbox.
-    pub highlighted_option_prefix: Styled<&'static str>,
+    pub highlighted_option_prefix: Styled<&'a str>,
 
     /// Prefix for the option listed at the top of the page, when it is possible
     /// to scroll up.
     ///
     /// Note: a space character will be added to separate the prefix
     /// and the option value or the checkbox.
-    pub scroll_up_prefix: Styled<&'static str>,
+    pub scroll_up_prefix: Styled<&'a str>,
 
     /// Prefix for the option listed at the bottom of the page, when it is possible
     /// to scroll down.
     ///
     /// Note: a space character will be added to separate the prefix
     /// and the option value or the checkbox.
-    pub scroll_down_prefix: Styled<&'static str>,
+    pub scroll_down_prefix: Styled<&'a str>,
 
     /// Selected checkbox in multi-select options.
     ///
     /// Note: a space character will be added to separate the checkbox
     /// from a possible prefix, and to separate the checkbox from the
     /// option value to the right.
-    pub selected_checkbox: Styled<&'static str>,
+    pub selected_checkbox: Styled<&'a str>,
 
     /// Unselected checkbox in multi-select options.
     ///
     /// Note: a space character will be added to separate the checkbox
     /// from a possible prefix, and to separate the checkbox from the
     /// option value to the right.
-    pub unselected_checkbox: Styled<&'static str>,
+    pub unselected_checkbox: Styled<&'a str>,
 
     /// Definition of index prefixes in option lists.
     pub option_index_prefix: IndexPrefix,
@@ -138,7 +138,7 @@ pub struct RenderConfig {
 
     #[cfg(feature = "date")]
     /// Render configuration for date prompts`
-    pub calendar: calendar::CalendarRenderConfig,
+    pub calendar: calendar::CalendarRenderConfig<'a>,
 
     /// Style sheet of the hint in editor prompts.
     ///
@@ -148,7 +148,7 @@ pub struct RenderConfig {
     pub editor_prompt: StyleSheet,
 }
 
-impl RenderConfig {
+impl<'a> RenderConfig<'a> {
     /// RenderConfig in which no colors or attributes are applied.
     pub fn empty() -> Self {
         Self {
@@ -212,7 +212,7 @@ impl RenderConfig {
     }
 
     /// Sets the prompt prefix and its style sheet.
-    pub fn with_prompt_prefix(mut self, prompt_prefix: Styled<&'static str>) -> Self {
+    pub fn with_prompt_prefix(mut self, prompt_prefix: Styled<&'a str>) -> Self {
         self.prompt_prefix = prompt_prefix;
         self
     }
@@ -242,7 +242,7 @@ impl RenderConfig {
     }
 
     /// Sets the render configuration for error messages.
-    pub fn with_error_message(mut self, error_message: ErrorMessageRenderConfig) -> Self {
+    pub fn with_error_message(mut self, error_message: ErrorMessageRenderConfig<'a>) -> Self {
         self.error_message = error_message;
         self
     }
@@ -250,32 +250,32 @@ impl RenderConfig {
     /// Sets the styled component for prefixes in highlighted options.
     pub fn with_highlighted_option_prefix(
         mut self,
-        highlighted_option_prefix: Styled<&'static str>,
+        highlighted_option_prefix: Styled<&'a str>,
     ) -> Self {
         self.highlighted_option_prefix = highlighted_option_prefix;
         self
     }
 
     /// Sets the styled component for prefixes in scroll-up indicators.
-    pub fn with_scroll_up_prefix(mut self, scroll_up_prefix: Styled<&'static str>) -> Self {
+    pub fn with_scroll_up_prefix(mut self, scroll_up_prefix: Styled<&'a str>) -> Self {
         self.scroll_up_prefix = scroll_up_prefix;
         self
     }
 
     /// Sets the styled component for prefixes in scroll-down indicators.
-    pub fn with_scroll_down_prefix(mut self, scroll_down_prefix: Styled<&'static str>) -> Self {
+    pub fn with_scroll_down_prefix(mut self, scroll_down_prefix: Styled<&'a str>) -> Self {
         self.scroll_down_prefix = scroll_down_prefix;
         self
     }
 
     /// Sets the styled component for selected checkboxes.
-    pub fn with_selected_checkbox(mut self, selected_checkbox: Styled<&'static str>) -> Self {
+    pub fn with_selected_checkbox(mut self, selected_checkbox: Styled<&'a str>) -> Self {
         self.selected_checkbox = selected_checkbox;
         self
     }
 
     /// Sets the styled component for unselected checkboxes.
-    pub fn with_unselected_checkbox(mut self, unselected_checkbox: Styled<&'static str>) -> Self {
+    pub fn with_unselected_checkbox(mut self, unselected_checkbox: Styled<&'a str>) -> Self {
         self.unselected_checkbox = unselected_checkbox;
         self
     }
@@ -301,7 +301,7 @@ impl RenderConfig {
     /// Sets the indicator for canceled prompts.
     pub fn with_canceled_prompt_indicator(
         mut self,
-        canceled_prompt_indicator: Styled<&'static str>,
+        canceled_prompt_indicator: Styled<&'a str>,
     ) -> Self {
         self.canceled_prompt_indicator = canceled_prompt_indicator;
         self
@@ -309,7 +309,7 @@ impl RenderConfig {
 
     #[cfg(feature = "date")]
     /// Sets the render configuration for calendars.
-    pub fn with_calendar_config(mut self, calendar: calendar::CalendarRenderConfig) -> Self {
+    pub fn with_calendar_config(mut self, calendar: calendar::CalendarRenderConfig<'a>) -> Self {
         self.calendar = calendar;
         self
     }
@@ -322,7 +322,7 @@ impl RenderConfig {
     }
 }
 
-impl Default for RenderConfig {
+impl<'a> Default for RenderConfig<'a> {
     fn default() -> Self {
         match env::var("NO_COLOR") {
             Ok(_) => Self::empty(),
@@ -369,9 +369,9 @@ pub enum IndexPrefix {
 
 /// Render configuration for error messages.
 #[derive(Copy, Clone, Debug)]
-pub struct ErrorMessageRenderConfig {
+pub struct ErrorMessageRenderConfig<'a> {
     /// Prefix style.
-    pub prefix: Styled<&'static str>,
+    pub prefix: Styled<&'a str>,
 
     /// Separator style.
     ///
@@ -383,10 +383,10 @@ pub struct ErrorMessageRenderConfig {
     pub message: StyleSheet,
 
     /// Default message used for validators that do not defined custom error messages.
-    pub default_message: &'static str,
+    pub default_message: &'a str,
 }
 
-impl ErrorMessageRenderConfig {
+impl<'a> ErrorMessageRenderConfig<'a> {
     /// Render configuration in which no colors or attributes are applied.
     pub fn empty() -> Self {
         Self {
@@ -408,7 +408,7 @@ impl ErrorMessageRenderConfig {
     }
 
     /// Sets the prefix.
-    pub fn with_prefix(mut self, prefix: Styled<&'static str>) -> Self {
+    pub fn with_prefix(mut self, prefix: Styled<&'a str>) -> Self {
         self.prefix = prefix;
         self
     }
@@ -437,9 +437,9 @@ pub mod calendar {
 
     /// Calendar configuration for error messages.
     #[derive(Copy, Clone, Debug)]
-    pub struct CalendarRenderConfig {
+    pub struct CalendarRenderConfig<'a> {
         /// Prefix style.
-        pub prefix: Styled<&'static str>,
+        pub prefix: Styled<&'a str>,
 
         /// Style sheet for the calendar header, e.g. january 2021.
         pub header: StyleSheet,
@@ -469,7 +469,7 @@ pub mod calendar {
         pub unavailable_date: StyleSheet,
     }
 
-    impl CalendarRenderConfig {
+    impl<'a> CalendarRenderConfig<'a> {
         /// Render configuration in which no colors or attributes are applied.
         pub fn empty() -> Self {
             Self {
@@ -501,7 +501,7 @@ pub mod calendar {
         }
 
         /// Sets the prefix.
-        pub fn with_prefix(mut self, prefix: Styled<&'static str>) -> Self {
+        pub fn with_prefix(mut self, prefix: Styled<&'a str>) -> Self {
             self.prefix = prefix;
             self
         }


### PR DESCRIPTION
Fixes #95.

This allows render configs to have a custom lifetime, giving more
freedom for further customization on the values, specially those
defined during runtime.
