### PR TITLE
Strip ANSI escape codes to compute cursor position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features
 
 - Allow lifetime customization of RenderConfig. [#101](https://github.com/mikaelmello/inquire/pull/101). Thanks to @arturfast for the suggestion [#95](https://github.com/mikaelmello/inquire/issues/95).
+- Allow usage of ANSI escape codes in prompts. [#136](https://github.com/mikaelmello/inquire/pull/136). Thanks to [@JimLynchCodes](https://github.com/JimLynchCodes) for reporting on [#135](https://github.com/mikaelmello/inquire/issues/135).
 
 ### Dependency changes (some breaking)
 

--- a/inquire/src/ansi.rs
+++ b/inquire/src/ansi.rs
@@ -46,17 +46,12 @@ fn match_escape_code(chars: Chars<'_>) -> MatchResult<'_> {
 
 /// An iterator that strips ANSI escape codes from a string.
 ///
-/// Generally constructed by calling [`strip_iter`].
-pub struct AnsiStripIter<'a> {
+/// Often constructed by calling [`ansi_stripped_chars`].
+pub struct AnsiStrippedChars<'a> {
     pub chars: Chars<'a>,
 }
 
-/// Constructs an iterator over the chars of the input string, stripping away ANSI escape codes.
-pub fn strip_iter(s: &str) -> AnsiStripIter<'_> {
-    AnsiStripIter { chars: s.chars() }
-}
-
-impl<'a> Iterator for AnsiStripIter<'a> {
+impl<'a> Iterator for AnsiStrippedChars<'a> {
     type Item = char;
 
     fn next(&mut self) -> Option<char> {
@@ -71,13 +66,26 @@ impl<'a> Iterator for AnsiStripIter<'a> {
     }
 }
 
+/// Constructs an iterator over the chars of the input string, stripping away ANSI escape codes.
+pub trait AnsiStrippable {
+    fn ansi_stripped_chars(&self) -> AnsiStrippedChars<'_>;
+}
+
+impl AnsiStrippable for &str {
+    fn ansi_stripped_chars(&self) -> AnsiStrippedChars<'_> {
+        AnsiStrippedChars {
+            chars: self.chars(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     macro_rules! assert_stripped_eq {
         ($input:expr, $expected:expr) => {
-            let stripped: String = strip_iter($input).collect();
+            let stripped: String = $input.ansi_stripped_chars().collect();
             assert_eq!(&stripped, $expected);
         };
     }

--- a/inquire/src/ansi.rs
+++ b/inquire/src/ansi.rs
@@ -6,41 +6,81 @@ enum MatchResult<'a> {
     NotMatched,
 }
 
-/// Match/consume the next ANSI escape code if it exists.
-/// The format is based on [this description](https://handwiki.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences)
-fn match_escape_code(chars: Chars<'_>) -> MatchResult<'_> {
-    let mut original_chars_iterator = chars;
-    let mut chars = original_chars_iterator.by_ref().peekable();
-
-    macro_rules! should_match {
-        ($c:expr, $pat:pat) => {
-            #[allow(unused_parens)]
-            match $c {
-                Some($pat) => {}
-                _ => return MatchResult::NotMatched,
-            }
-        };
-    }
-
-    // match \x1b[
-    should_match!(chars.next(), '\x1b');
-    should_match!(chars.next(), '[');
-
-    // match [0–9:;<=>?]*
-    while let Some('0'..='?') = chars.peek() {
-        chars.next();
-    }
-
-    // match [ !"#$%&'()*+,-./]
-    while let Some(' '..='/') = chars.peek() {
-        chars.next();
-    }
-
-    // match [@A–Z[\]^_`a–z{|}~]
-    should_match!(chars.next(), '@'..='~');
-
+fn matched(chars: Chars<'_>) -> MatchResult<'_> {
     MatchResult::Matched {
-        remaining_chars: original_chars_iterator,
+        remaining_chars: chars,
+    }
+}
+
+/// Matches an ANSI escape code according to a simplified version of
+/// [this description](https://vt100.net/emu/dec_ansi_parser). As we only want to know when the
+/// automaton gets out of/reaches the "ground" state, we only keep track of transitions leading
+/// out of it/into it.
+///
+/// The only way to get out of the ground is to read the escape character ('\x1b'). Transitions
+/// like "anywhere -- \x9b -> csi_entry" are not supported, as few terminals implement them.
+struct Matcher<'a> {
+    chars: Chars<'a>,
+}
+
+impl<'a> Matcher<'a> {
+    fn new(chars: Chars<'a>) -> Self {
+        Self { chars }
+    }
+
+    #[inline]
+    fn run(mut self) -> MatchResult<'a> {
+        match self.chars.next() {
+            Some('\x1b') => self.escape(),
+            _ => MatchResult::NotMatched,
+        }
+    }
+
+    #[inline]
+    fn next(&mut self) -> Option<u32> {
+        self.chars.next().map(|c| c as u32)
+    }
+
+    fn escape(mut self) -> MatchResult<'a> {
+        match self.next() {
+            None => matched(self.chars),
+            Some(0x1B) =>  self.escape(),
+            Some(0x7F) => self.escape(),
+            Some(0x5B) => self.csi_entry(),
+            Some(0x5D) => self.string(), // osc_string
+            Some(0x50) => self.string(), // dcs_entry
+            Some(0x58 | 0x5E | 0x5F) => self.string(), // sos/pm/apc_string
+            Some(0x20..=0x2F) => self.escape_intermediate(),
+            Some(0x30..=0x4F | 0x51..=0x57 | 0x59 | 0x5A | 0x5C | 0x60..=0x7E) => {
+                matched(self.chars)
+            }
+            _ => self.escape(),
+        }
+    }
+
+    fn csi_entry(mut self) -> MatchResult<'a> {
+        match self.next() {
+            Some(0x1B) => self.escape(),
+            None | Some(0x40..=0x7E) => matched(self.chars),
+            _ => self.csi_entry(), // loop until match
+        }
+    }
+
+    fn escape_intermediate(mut self) -> MatchResult<'a> {
+        match self.next() {
+            Some(0x1B) => self.escape(),
+            None | Some(0x30..=0x7E) => matched(self.chars),
+            _ => self.escape_intermediate(), // loop until match
+        }
+    }
+
+    /// Matches until the end of sos/pm/apc strings, dcs entries and osc strings.
+    fn string(mut self) -> MatchResult<'a> {
+        match self.next() {
+            Some(0x1B) => self.escape(),
+            None | Some(0x07 | 0x9C) => matched(self.chars),
+            _ => self.string(), // loop until match
+        }
     }
 }
 
@@ -56,7 +96,7 @@ impl<'a> Iterator for AnsiStrippedChars<'a> {
 
     fn next(&mut self) -> Option<char> {
         let chars = self.chars.clone();
-        match match_escape_code(chars) {
+        match Matcher::new(chars).run() {
             MatchResult::Matched { remaining_chars } => {
                 self.chars = remaining_chars;
                 self.next()
@@ -91,10 +131,24 @@ mod tests {
     }
 
     #[test]
-    fn strips_ansi_codes() {
+    fn test_normal_ansi_escapes() {
         assert_stripped_eq!("1\x1b[0m2", "12");
         assert_stripped_eq!("\x1b[92mHello, \x1b[91mWorld!\x1b[0m", "Hello, World!");
-        assert_stripped_eq!("\x1b[\x1b[38;5;43mAB\x1b[48;5;10mCD\x1b[0m", "\x1b[ABCD");
         assert_stripped_eq!("\x1b[7@Hi", "Hi");
+        assert_stripped_eq!("\x1b]0;Set The Terminal Title To This\u{9c}Print This", "Print This");
+        assert_stripped_eq!("\x1b[96", "");
+    }
+
+    #[test]
+    // Please don't use ansi escapes like these!
+    fn test_inconsistencies() {
+        // Some terminals will print "String\u{9c}Hello World", others will print nothing.
+        assert_stripped_eq!("\x1b[\x1b]String\u{9c}Hello World", "Hello World");
+
+        // Kitty will print "[38;5;43mABCD", but most will print "ABCD"
+        assert_stripped_eq!("\x1b[\x1b[38;5;43mAB\x1b[48;5;10mCD\x1b[0m", "ABCD");
+
+        // Kitty will print "[96mCat\n", but most will print "Cat\n"
+        assert_stripped_eq!("\x1b\x19[96mCat\x1b[0m\n", "Cat\n");
     }
 }

--- a/inquire/src/ansi.rs
+++ b/inquire/src/ansi.rs
@@ -44,11 +44,11 @@ impl<'a> Matcher<'a> {
     fn escape(mut self) -> MatchResult<'a> {
         match self.next() {
             None => matched(self.chars),
-            Some(0x1B) =>  self.escape(),
+            Some(0x1B) => self.escape(),
             Some(0x7F) => self.escape(),
             Some(0x5B) => self.csi_entry(),
-            Some(0x5D) => self.string(), // osc_string
-            Some(0x50) => self.string(), // dcs_entry
+            Some(0x5D) => self.string(),               // osc_string
+            Some(0x50) => self.string(),               // dcs_entry
             Some(0x58 | 0x5E | 0x5F) => self.string(), // sos/pm/apc_string
             Some(0x20..=0x2F) => self.escape_intermediate(),
             Some(0x30..=0x4F | 0x51..=0x57 | 0x59 | 0x5A | 0x5C | 0x60..=0x7E) => {
@@ -135,7 +135,10 @@ mod tests {
         assert_stripped_eq!("1\x1b[0m2", "12");
         assert_stripped_eq!("\x1b[92mHello, \x1b[91mWorld!\x1b[0m", "Hello, World!");
         assert_stripped_eq!("\x1b[7@Hi", "Hi");
-        assert_stripped_eq!("\x1b]0;Set The Terminal Title To This\u{9c}Print This", "Print This");
+        assert_stripped_eq!(
+            "\x1b]0;Set The Terminal Title To This\u{9c}Print This",
+            "Print This"
+        );
         assert_stripped_eq!("\x1b[96", "");
     }
 

--- a/inquire/src/ansi.rs
+++ b/inquire/src/ansi.rs
@@ -1,0 +1,92 @@
+use std::str::Chars;
+
+#[must_use]
+enum MatchResult<'a> {
+    Matched { remaining_chars: Chars<'a> },
+    NotMatched,
+}
+
+/// Match/consume the next ANSI escape code if it exists.
+/// The format is based on [this description](https://handwiki.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences)
+fn match_escape_code(chars: Chars<'_>) -> MatchResult<'_> {
+    let mut original_chars_iterator = chars;
+    let mut chars = original_chars_iterator.by_ref().peekable();
+
+    macro_rules! should_match {
+        ($c:expr, $pat:pat) => {
+            #[allow(unused_parens)]
+            match $c {
+                Some($pat) => {}
+                _ => return MatchResult::NotMatched,
+            }
+        };
+    }
+
+    // match \x1b[
+    should_match!(chars.next(), '\x1b');
+    should_match!(chars.next(), '[');
+
+    // match [0–9:;<=>?]*
+    while let Some('0'..='?') = chars.peek() {
+        chars.next();
+    }
+
+    // match [ !"#$%&'()*+,-./]
+    while let Some(' '..='/') = chars.peek() {
+        chars.next();
+    }
+
+    // match [@A–Z[\]^_`a–z{|}~]
+    should_match!(chars.next(), '@'..='~');
+
+    MatchResult::Matched {
+        remaining_chars: original_chars_iterator,
+    }
+}
+
+/// An iterator that strips ANSI escape codes from a string.
+///
+/// Generally constructed by calling [`strip_iter`].
+pub struct AnsiStripIter<'a> {
+    pub chars: Chars<'a>,
+}
+
+/// Constructs an iterator over the chars of the input string, stripping away ANSI escape codes.
+pub fn strip_iter(s: &str) -> AnsiStripIter<'_> {
+    AnsiStripIter { chars: s.chars() }
+}
+
+impl<'a> Iterator for AnsiStripIter<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        let chars = self.chars.clone();
+        match match_escape_code(chars) {
+            MatchResult::Matched { remaining_chars } => {
+                self.chars = remaining_chars;
+                self.next()
+            }
+            MatchResult::NotMatched => self.chars.next(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_stripped_eq {
+        ($input:expr, $expected:expr) => {
+            let stripped: String = strip_iter($input).collect();
+            assert_eq!(&stripped, $expected);
+        };
+    }
+
+    #[test]
+    fn strips_ansi_codes() {
+        assert_stripped_eq!("1\x1b[0m2", "12");
+        assert_stripped_eq!("\x1b[92mHello, \x1b[91mWorld!\x1b[0m", "Hello, World!");
+        assert_stripped_eq!("\x1b[\x1b[38;5;43mAB\x1b[48;5;10mCD\x1b[0m", "\x1b[ABCD");
+        assert_stripped_eq!("\x1b[7@Hi", "Hi");
+    }
+}

--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -80,6 +80,7 @@ mod terminal;
 pub mod type_aliases;
 pub mod ui;
 mod utils;
+mod ansi;
 pub mod validator;
 
 pub use crate::autocompletion::Autocomplete;

--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -66,6 +66,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::bool_to_int_with_if)]
+mod ansi;
 pub mod autocompletion;
 mod config;
 #[cfg(feature = "date")]
@@ -80,7 +81,6 @@ mod terminal;
 pub mod type_aliases;
 pub mod ui;
 mod utils;
-mod ansi;
 pub mod validator;
 
 pub use crate::autocompletion::Autocomplete;

--- a/inquire/src/ui/backend.rs
+++ b/inquire/src/ui/backend.rs
@@ -1,3 +1,4 @@
+use crate::ansi::AnsiStrippable;
 use std::{collections::BTreeSet, fmt::Display, io::Result};
 
 use unicode_width::UnicodeWidthChar;
@@ -120,7 +121,7 @@ where
 
         let mut cur_pos = Position::default();
 
-        for (idx, c) in crate::ansi::strip_iter(input).enumerate() {
+        for (idx, c) in input.ansi_stripped_chars().enumerate() {
             let len = UnicodeWidthChar::width(c).unwrap_or(0) as u16;
 
             if c == '\n' {

--- a/inquire/src/ui/backend.rs
+++ b/inquire/src/ui/backend.rs
@@ -120,7 +120,7 @@ where
 
         let mut cur_pos = Position::default();
 
-        for (idx, c) in input.chars().enumerate() {
+        for (idx, c) in crate::ansi::strip_iter(input).enumerate() {
             let len = UnicodeWidthChar::width(c).unwrap_or(0) as u16;
 
             if c == '\n' {


### PR DESCRIPTION
An attempt to fix #135

I added a module `crate::ansi` that parses ANSI escape codes according to [this description](https://handwiki.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences), which is then used to skip them when calculating the cursor position on `frame_finish()`;

Note that there are some rendering inconsistencies for ANSI codes between terminals, so it's impossible to make this work for every escape sequence in every terminal, but for non-pathological escape codes I think this implementation should be fine.
  
Pictured: inconsistencies between Kitty, Wezterm and Alacritty.
![Screenshot_20230427_002742](https://user-images.githubusercontent.com/8211902/234757069-6f550373-a59b-4c80-9079-3c9274d2f530.jpg)

![Screenshot_20230427_005333](https://user-images.githubusercontent.com/8211902/234757394-b4c7e760-9f5b-482b-8fa9-dc6e7bf2387c.jpg)

