### PR TITLE
Replace lazy static dep with once cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed `thiserror` dependency in favor of implementing `InquireError` by hand. [#146](https://github.com/mikaelmello/inquire/issues/146)
 - Raised MSRV to 1.60 due to `log` dependency raising their MSRV to 1.60.
 - MSRV is now explicitly set in the package definition.
+- Replaced `lazy_static` with `once_cell` as `once_cell::sync::Lazy` is being standardized and `lazy_static` is not actively maintained anymore.
 
 ## [0.6.2] - 2023-05-07
 

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -41,9 +41,8 @@ tempfile = { version = "3", optional = true }
 
 bitflags = "2"
 dyn-clone = "1"
-lazy_static = "1.4"
 newline-converter = "0.3"
-
+once_cell = "1.18.0"
 unicode-segmentation = "1"
 unicode-width = "0.1"
 

--- a/inquire/src/config.rs
+++ b/inquire/src/config.rs
@@ -2,14 +2,12 @@
 
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use crate::ui::RenderConfig;
 
-lazy_static! {
-    static ref GLOBAL_RENDER_CONFIGURATION: Mutex<RenderConfig<'static>> =
-        Mutex::new(RenderConfig::default());
-}
+static GLOBAL_RENDER_CONFIGURATION: Lazy<Mutex<RenderConfig<'static>>> =
+    Lazy::new(|| Mutex::new(RenderConfig::default()));
 
 pub fn get_configuration() -> RenderConfig<'static> {
     *GLOBAL_RENDER_CONFIGURATION.lock().unwrap()

--- a/inquire/src/prompts/editor/mod.rs
+++ b/inquire/src/prompts/editor/mod.rs
@@ -9,7 +9,7 @@ use std::{
     ffi::{OsStr, OsString},
 };
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use crate::{
     error::{InquireError, InquireResult},
@@ -22,9 +22,7 @@ use crate::{
 
 use self::prompt::EditorPrompt;
 
-lazy_static! {
-    static ref DEFAULT_EDITOR: OsString = get_default_editor_command();
-}
+static DEFAULT_EDITOR: Lazy<OsString> = Lazy::new(get_default_editor_command);
 
 /// This prompt is meant for cases where you need the user to write some text that might not fit in a single line, such as long descriptions or commit messages.
 ///


### PR DESCRIPTION
Replaced `lazy_static` with `once_cell` as `once_cell::sync::Lazy` is being standardized and `lazy_static` is not actively maintained anymore.