### PR TITLE
Don't `.reserve()` without a need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 - MSRV is now explicitly set in the package definition.
 - Replaced `lazy_static` with `once_cell` as `once_cell::sync::Lazy` is being standardized and `lazy_static` is not actively maintained anymore.
 
+### Internals
+
+- Removed some useless `Vec::reserve()` calls
+
 ## [0.6.2] - 2023-05-07
 
 - Allow usage of ANSI escape codes in prompts. [#136](https://github.com/mikaelmello/inquire/pull/136). Thanks to [@JimLynchCodes](https://github.com/JimLynchCodes) for reporting on [#135](https://github.com/mikaelmello/inquire/issues/135).

--- a/inquire/src/prompts/custom_type/mod.rs
+++ b/inquire/src/prompts/custom_type/mod.rs
@@ -196,12 +196,6 @@ where
     where
         V: CustomTypeValidator<T> + 'static,
     {
-        // Directly make space for at least 5 elements, so we won't to re-allocate too often when
-        // calling this function repeatedly.
-        if self.validators.capacity() == 0 {
-            self.validators.reserve(5);
-        }
-
         self.validators.push(Box::new(validator));
         self
     }

--- a/inquire/src/prompts/dateselect/mod.rs
+++ b/inquire/src/prompts/dateselect/mod.rs
@@ -201,12 +201,6 @@ impl<'a> DateSelect<'a> {
     where
         V: DateValidator + 'static,
     {
-        // Directly make space for at least 5 elements, so we won't to re-allocate too often when
-        // calling this function repeatedly.
-        if self.validators.capacity() == 0 {
-            self.validators.reserve(5);
-        }
-
         self.validators.push(Box::new(validator));
         self
     }

--- a/inquire/src/prompts/editor/mod.rs
+++ b/inquire/src/prompts/editor/mod.rs
@@ -163,12 +163,6 @@ impl<'a> Editor<'a> {
     where
         V: StringValidator + 'static,
     {
-        // Directly make space for at least 5 elements, so we won't to re-allocate too often when
-        // calling this function repeatedly.
-        if self.validators.capacity() == 0 {
-            self.validators.reserve(5);
-        }
-
         self.validators.push(Box::new(validator));
         self
     }

--- a/inquire/src/prompts/password/mod.rs
+++ b/inquire/src/prompts/password/mod.rs
@@ -218,12 +218,6 @@ impl<'a> Password<'a> {
     where
         V: StringValidator + 'static,
     {
-        // Directly make space for at least 5 elements, so we won't to re-allocate too often when
-        // calling this function repeatedly.
-        if self.validators.capacity() == 0 {
-            self.validators.reserve(5);
-        }
-
         self.validators.push(Box::new(validator));
         self
     }

--- a/inquire/src/prompts/text/mod.rs
+++ b/inquire/src/prompts/text/mod.rs
@@ -212,12 +212,6 @@ impl<'a> Text<'a> {
     where
         V: StringValidator + 'static,
     {
-        // Directly make space for at least 5 elements, so we won't to re-allocate too often when
-        // calling this function repeatedly.
-        if self.validators.capacity() == 0 {
-            self.validators.reserve(5);
-        }
-
         self.validators.push(Box::new(validator));
         self
     }


### PR DESCRIPTION
Note that `.push()` already reserve space for at least 4 elements (see [here](https://github.com/rust-lang/rust/blob/3e50a641da8e97d79dad71202671f35918d6473c/library/alloc/src/raw_vec.rs#L399) and [here](https://github.com/rust-lang/rust/blob/3e50a641da8e97d79dad71202671f35918d6473c/library/alloc/src/raw_vec.rs#L105-L116)), so a `.reserve(5)` most likely doesn't do anything useful.