### PR TITLE
Mention when to enable the 'editor' feature

### DIFF
--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -28,7 +28,7 @@
 //!   - Custom extensions for files created by [`Editor`] prompts;
 //!   - and many others!
 //!
-//! \* Date-related features are available by enabling the `date` feature.
+//! \* Date-related features are available by enabling the `date` feature and enable the `editor` feature for the text editor features
 //!
 //! # Simple Example
 //!

--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -15,7 +15,7 @@
 //! \* The Editor and DateSelect prompts are available by enabling the `editor` and `date` features, respectively.
 //!
 //! Check out the [GitHub repository](https://github.com/mikaelmello/inquire) to see demos of what you can do with `inquire`.
-//! 
+//!
 //! # Features
 //!
 //! - Cross-platform, supporting UNIX and Windows terminals (thanks to [crossterm](https://crates.io/crates/crossterm));

--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -30,8 +30,6 @@
 //!   - Custom extensions for files created by [`Editor`] prompts;
 //!   - and many others!
 //!
-//! \* Date-related features are available by enabling the `date` feature and enable the `editor` feature for the text editor features
-//!
 //! # Simple Example
 //!
 //! ```rust no_run

--- a/inquire/src/lib.rs
+++ b/inquire/src/lib.rs
@@ -12,8 +12,10 @@
 //! - [`CustomType`] for text prompts that you would like to parse to a custom type, such as numbers or UUIDs;
 //! - [`Password`] for secretive text prompts.
 //!
-//! Check out the [GitHub repository](https://github.com/mikaelmello/inquire) to see demos of what you can do with `inquire`.
+//! \* The Editor and DateSelect prompts are available by enabling the `editor` and `date` features, respectively.
 //!
+//! Check out the [GitHub repository](https://github.com/mikaelmello/inquire) to see demos of what you can do with `inquire`.
+//! 
 //! # Features
 //!
 //! - Cross-platform, supporting UNIX and Windows terminals (thanks to [crossterm](https://crates.io/crates/crossterm));


### PR DESCRIPTION
I was confused at how to enable the Editor feature, which is to enable
the `editor` feature. Which is obvious in hindsight. This small doc PR
is meant to help prevent this point of confusion in the future.