### PR TITLE
Upgrade MSRV to 1.63.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  MSRV: 1.60.0
+  MSRV: 1.63.0
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Upgraded underlying `termion` crate from v1.5 to v2.0.
 - Upgraded underlying `bitflags` from v1 to v2, which affects the `Attributes` and `KeyModifiers` crates. If you use any of bitflag's methods directly, you might be affected, refer to the [bitflags changelog](https://github.com/bitflags/bitflags/releases/tag/2.0.0) for more information.
 - Removed `thiserror` dependency in favor of implementing `InquireError` by hand. [#146](https://github.com/mikaelmello/inquire/issues/146)
-- Raised MSRV to 1.60 due to `log` dependency raising their MSRV to 1.60.
+- Raised MSRV to 1.63 due to requirements in downstream dependencies.
 - MSRV is now explicitly set in the package definition.
 - Replaced `lazy_static` with `once_cell` as `once_cell::sync::Lazy` is being standardized and `lazy_static` is not actively maintained anymore.
 

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -33,11 +33,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 crossterm = { version = "0.25", optional = true }
 termion = { version = "2.0", optional = true }
-console = { version = "0.15", optional = true, features = ["windows-console-colors"] }
+console = { version = "0.15", optional = true, features = [
+  "windows-console-colors",
+] }
 
 chrono = { version = "0.4", optional = true }
 
-tempfile = { version = "3", optional = true }
+tempfile = { version = "3.5", optional = true }
 
 bitflags = "2"
 dyn-clone = "1"

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Mikael Mello <git@mikaelmello.com>"]
 keywords = ["cli", "ask", "prompt", "question", "interactive"]
 categories = ["command-line-interface", "value-formatting"]
 include = ["/examples", "/src", "/../LICENSE"]
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 
 [lib]
 name = "inquire"
@@ -39,7 +39,7 @@ console = { version = "0.15", optional = true, features = [
 
 chrono = { version = "0.4", optional = true }
 
-tempfile = { version = "3.5", optional = true }
+tempfile = { version = "3", optional = true }
 
 bitflags = "2"
 dyn-clone = "1"


### PR DESCRIPTION
Fixes MSRV issue with downstream rustix dependency that has a higher MSRV than ours
