### PR TITLE
Accept Ctrl-p and Ctrl-n as up and down by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add strict clippy lints to improve code consistency and readability.
 - Expand workflow clippy task to lint all-features in workspace.
 - Add docs badge to readme.
+- Keybindings Ctrl-p and Ctrl-n added for Up and Down actions
 
 ### Fixes
 

--- a/inquire/src/prompts/multiselect/action.rs
+++ b/inquire/src/prompts/multiselect/action.rs
@@ -47,11 +47,11 @@ impl InnerAction for MultiSelectPromptAction {
         }
 
         let action = match key {
-            Key::Up(KeyModifiers::NONE) => Self::MoveUp,
+            Key::Up(KeyModifiers::NONE) | Key::Char('p', KeyModifiers::CONTROL) => Self::MoveUp,
             Key::PageUp => Self::PageUp,
             Key::Home => Self::MoveToStart,
 
-            Key::Down(KeyModifiers::NONE) => Self::MoveDown,
+            Key::Down(KeyModifiers::NONE) | Key::Char('n', KeyModifiers::CONTROL) => Self::MoveDown,
             Key::PageDown => Self::PageDown,
             Key::End => Self::MoveToEnd,
 

--- a/inquire/src/prompts/select/action.rs
+++ b/inquire/src/prompts/select/action.rs
@@ -41,11 +41,11 @@ impl InnerAction for SelectPromptAction {
         }
 
         let action = match key {
-            Key::Up(KeyModifiers::NONE) => Self::MoveUp,
+            Key::Up(KeyModifiers::NONE) | Key::Char('p', KeyModifiers::CONTROL) => Self::MoveUp,
             Key::PageUp => Self::PageUp,
             Key::Home => Self::MoveToStart,
 
-            Key::Down(KeyModifiers::NONE) => Self::MoveDown,
+            Key::Down(KeyModifiers::NONE) | Key::Char('n', KeyModifiers::CONTROL) => Self::MoveDown,
             Key::PageDown => Self::PageDown,
             Key::End => Self::MoveToEnd,
 

--- a/inquire/src/prompts/text/action.rs
+++ b/inquire/src/prompts/text/action.rs
@@ -28,10 +28,14 @@ impl InnerAction for TextPromptAction {
 
     fn from_key(key: Key, _config: &TextConfig) -> Option<Self> {
         let action = match key {
-            Key::Up(KeyModifiers::NONE) => Self::MoveToSuggestionAbove,
+            Key::Up(KeyModifiers::NONE) | Key::Char('p', KeyModifiers::CONTROL) => {
+                Self::MoveToSuggestionAbove
+            }
             Key::PageUp => Self::MoveToSuggestionPageUp,
 
-            Key::Down(KeyModifiers::NONE) => Self::MoveToSuggestionBelow,
+            Key::Down(KeyModifiers::NONE) | Key::Char('n', KeyModifiers::CONTROL) => {
+                Self::MoveToSuggestionBelow
+            }
             Key::PageDown => Self::MoveToSuggestionPageDown,
 
             Key::Tab => Self::UseCurrentSuggestion,


### PR DESCRIPTION
Would you consider a small subset of emacs like bindings?

Many prompts accept ctrl-p and ctrl-n as up and down with no specific Emacs support, and it doesn't appear to conflict with anything, so accept these select and multi-select.
