### PR TITLE
Adds 'starting_filter_input' to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Implement fuzzy search as default on Select and MultiSelect prompts. [#176](https://github.com/mikaelmello/inquire/pull/176)
 - Add new option on Select/MultiSelect prompts allowing to reset selection to the first item on filter-input changes. [#176](https://github.com/mikaelmello/inquire/pull/176)
 - Keybindings Ctrl-p and Ctrl-n added for Up and Down actions
+- Added 'with_starting_filter_input' to both Select and MultiSelect, which allows for setting an initial value to the filter section of the prompt.
 
 ### Fixes
 

--- a/inquire/src/prompts/multiselect/mod.rs
+++ b/inquire/src/prompts/multiselect/mod.rs
@@ -44,6 +44,7 @@ static DEFAULT_MATCHER: Lazy<SkimMatcherV2> = Lazy::new(|| SkimMatcherV2::defaul
 /// - **Options list**: Options displayed to the user. Must be **non-empty**.
 /// - **Default selections**: Options that are selected by default when the prompt is first rendered. The user can unselect them. If any of the indices is out-of-range of the option list, the prompt will fail with an [`InquireError::InvalidConfiguration`] error.
 /// - **Starting cursor**: Index of the cursor when the prompt is first rendered. Default is 0 (first option). If the index is out-of-range of the option list, the prompt will fail with an [`InquireError::InvalidConfiguration`] error.
+/// - **Starting filter input**: Sets the initial value of the filter section of the prompt.
 /// - **Help message**: Message displayed at the line below the prompt.
 /// - **Formatter**: Custom formatter in case you need to pre-process the user input before showing it as the final answer.
 ///   - Prints the selected options string value, joined using a comma as the separator, by default.
@@ -82,6 +83,9 @@ pub struct MultiSelect<'a, T> {
 
     /// Starting cursor index of the selection.
     pub starting_cursor: usize,
+
+    /// Starting filter input
+    pub starting_filter_input: Option<&'a str>,
 
     /// Reset cursor position to first option on filter input change.
     /// Defaults to true.
@@ -214,6 +218,7 @@ where
             page_size: Self::DEFAULT_PAGE_SIZE,
             vim_mode: Self::DEFAULT_VIM_MODE,
             starting_cursor: Self::DEFAULT_STARTING_CURSOR,
+            starting_filter_input: None,
             reset_cursor: Self::DEFAULT_RESET_CURSOR,
             keep_filter: Self::DEFAULT_KEEP_FILTER,
             scorer: Self::DEFAULT_SCORER,
@@ -299,6 +304,12 @@ where
     /// Sets the starting cursor index.
     pub fn with_starting_cursor(mut self, starting_cursor: usize) -> Self {
         self.starting_cursor = starting_cursor;
+        self
+    }
+
+    /// Sets the starting filter input
+    pub fn with_starting_filter_input(mut self, starting_filter_input: &'a str) -> Self {
+        self.starting_filter_input = Some(starting_filter_input);
         self
     }
 

--- a/inquire/src/prompts/multiselect/prompt.rs
+++ b/inquire/src/prompts/multiselect/prompt.rs
@@ -74,7 +74,10 @@ where
             scored_options,
             help_message: mso.help_message,
             cursor_index: mso.starting_cursor,
-            input: Input::new(),
+            input: mso
+                .starting_filter_input
+                .map(Input::new_with)
+                .unwrap_or_else(Input::new),
             scorer: mso.scorer,
             formatter: mso.formatter,
             validator: mso.validator,

--- a/inquire/src/prompts/select/mod.rs
+++ b/inquire/src/prompts/select/mod.rs
@@ -43,6 +43,7 @@ static DEFAULT_MATCHER: Lazy<SkimMatcherV2> = Lazy::new(|| SkimMatcherV2::defaul
 /// - **Prompt message**: Required when creating the prompt.
 /// - **Options list**: Options displayed to the user. Must be **non-empty**.
 /// - **Starting cursor**: Index of the cursor when the prompt is first rendered. Default is 0 (first option). If the index is out-of-range of the option list, the prompt will fail with an [`InquireError::InvalidConfiguration`] error.
+/// - **Starting filter input**: Sets the initial value of the filter section of the prompt.
 /// - **Help message**: Message displayed at the line below the prompt.
 /// - **Formatter**: Custom formatter in case you need to pre-process the user input before showing it as the final answer.
 ///   - Prints the selected option string value by default.
@@ -88,6 +89,9 @@ pub struct Select<'a, T> {
 
     /// Starting cursor index of the selection.
     pub starting_cursor: usize,
+
+    /// Starting filter input
+    pub starting_filter_input: Option<&'a str>,
 
     /// Reset cursor position to first option on filter input change.
     /// Defaults to true.
@@ -199,6 +203,7 @@ where
             scorer: Self::DEFAULT_SCORER,
             formatter: Self::DEFAULT_FORMATTER,
             render_config: get_configuration(),
+            starting_filter_input: None,
         }
     }
 
@@ -241,6 +246,12 @@ where
     /// Sets the starting cursor index.
     pub fn with_starting_cursor(mut self, starting_cursor: usize) -> Self {
         self.starting_cursor = starting_cursor;
+        self
+    }
+
+    /// Sets the starting filter input
+    pub fn with_starting_filter_input(mut self, starting_filter_input: &'a str) -> Self {
+        self.starting_filter_input = Some(starting_filter_input);
         self
     }
 

--- a/inquire/src/prompts/select/prompt.rs
+++ b/inquire/src/prompts/select/prompt.rs
@@ -59,8 +59,8 @@ where
             cursor_index: so.starting_cursor,
             input: so
                 .starting_filter_input
-                .map(|si| Input::new_with(si))
-                .unwrap_or_else(|| Input::new()),
+                .map(Input::new_with)
+                .unwrap_or_else(Input::new),
             scorer: so.scorer,
             formatter: so.formatter,
         })

--- a/inquire/src/prompts/select/prompt.rs
+++ b/inquire/src/prompts/select/prompt.rs
@@ -57,7 +57,10 @@ where
             scored_options,
             help_message: so.help_message,
             cursor_index: so.starting_cursor,
-            input: Input::new(),
+            input: so
+                .starting_filter_input
+                .map(|si| Input::new_with(si))
+                .unwrap_or_else(|| Input::new()),
             scorer: so.scorer,
             formatter: so.formatter,
         })


### PR DESCRIPTION
This adds the option to set an initial filter value to the Select prompt.
My use-case it to allow  the user to start a command with some initial input, if that doesn't match anything directly, build a Select prompt with their initial value as a starting point.

The current implementation does exhibit a (usual) problem, in that the contents is not yet filtered until the user takes another action. (for example, deleting a character). My first attempt at solving that resulted in a much larger PR, and would like your input if it is worth the effort (and if so, the best approach at solving it).

If this is something you could see working, I would be happy to add this to other prompts.