### PR TITLE
Add emacs-like cursor navigation to dateselect; fix lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
     `Some(score)`: score determines the order of options, higher score, higher on the list of options.
 - Implement fuzzy search as default on Select and MultiSelect prompts. [#176](https://github.com/mikaelmello/inquire/pull/176)
 - Add new option on Select/MultiSelect prompts allowing to reset selection to the first item on filter-input changes. [#176](https://github.com/mikaelmello/inquire/pull/176)
-- Keybindings Ctrl-p and Ctrl-n added for Up and Down actions
+- Keybindings Ctrl-p and Ctrl-n added for up and down actions, additionally dateselect will accept Ctrl-b and Ctrl-f as left and right actions
 
 ### Fixes
 

--- a/inquire/src/prompts/dateselect/action.rs
+++ b/inquire/src/prompts/dateselect/action.rs
@@ -46,10 +46,18 @@ impl InnerAction for DateSelectPromptAction {
         }
 
         let action = match key {
-            Key::Left(KeyModifiers::NONE) => Self::GoToPrevDay,
-            Key::Right(KeyModifiers::NONE) => Self::GoToNextDay,
-            Key::Up(KeyModifiers::NONE) => Self::GoToPrevWeek,
-            Key::Down(KeyModifiers::NONE) | Key::Tab => Self::GoToNextWeek,
+            Key::Left(KeyModifiers::NONE) | Key::Char('b', KeyModifiers::CONTROL) => {
+                Self::GoToPrevDay
+            }
+            Key::Right(KeyModifiers::NONE) | Key::Char('f', KeyModifiers::CONTROL) => {
+                Self::GoToNextDay
+            }
+            Key::Up(KeyModifiers::NONE) | Key::Char('p', KeyModifiers::CONTROL) => {
+                Self::GoToPrevWeek
+            }
+            Key::Down(KeyModifiers::NONE) | Key::Char('n', KeyModifiers::CONTROL) | Key::Tab => {
+                Self::GoToNextWeek
+            }
             Key::Left(KeyModifiers::CONTROL) => Self::GoToPrevMonth,
             Key::Right(KeyModifiers::CONTROL) => Self::GoToNextMonth,
             Key::Up(KeyModifiers::CONTROL) => Self::GoToPrevYear,

--- a/inquire/src/prompts/multiselect/prompt.rs
+++ b/inquire/src/prompts/multiselect/prompt.rs
@@ -64,7 +64,7 @@ where
                     .filter(|i| *i < mso.options.len())
                     .collect()
             })
-            .unwrap_or_else(BTreeSet::new);
+            .unwrap_or_default();
 
         Ok(Self {
             message: mso.message,


### PR DESCRIPTION
Accept Ctrl-p and Ctrl-b as up and down. Additionally accept Ctrl-b
and Ctrl-f as left and right.
