### PR TITLE
Adds emacs/readline keys C-g (Cancel) and C-j (Enter).

### DIFF
--- a/inquire/src/prompts/action.rs
+++ b/inquire/src/prompts/action.rs
@@ -37,7 +37,9 @@ where
     {
         match key {
             Key::Enter => Some(Action::Submit),
+            Key::Char('j', KeyModifiers::CONTROL) => Some(Action::Submit),
             Key::Escape => Some(Action::Cancel),
+            Key::Char('g', KeyModifiers::CONTROL) => Some(Action::Cancel),
             Key::Char('c', KeyModifiers::CONTROL) => Some(Action::Interrupt),
             key => I::from_key(key, config).map(Action::Inner),
         }


### PR DESCRIPTION
I really appreciate the change in #180 to add basic emacs keys, because they are used in many places outside of emacs too (in readline). Theres two more though that I would like to use : 

 * C-g to cancel
 * C-j to press Enter

These are both in readline AFAIK and are not emacs specific.