### PR TITLE
Fix broken links in markdown docs

### DIFF
--- a/KEY_BINDINGS.md
+++ b/KEY_BINDINGS.md
@@ -124,5 +124,5 @@ These key bindings may be used in [`Editor`] prompts.
 [`MultiSelect`]: https://docs.rs/inquire/*/inquire/prompts/multiselect/struct.MultiSelect.html
 [`Confirm`]: https://docs.rs/inquire/*/inquire/prompts/confirm/struct.Confirm.html
 [`Editor`]: https://docs.rs/inquire/*/inquire/prompts/editor/struct.Editor.html
-[`CustomType`]: https://docs.rs/inquire/*/inquire/prompts/customtype/struct.CustomType.html
+[`customtype`]: https://docs.rs/inquire/*/inquire/struct.CustomType.html
 [`Password`]: https://docs.rs/inquire/*/inquire/prompts/password/struct.Password.html

--- a/inquire-derive/CRATE_README.md
+++ b/inquire-derive/CRATE_README.md
@@ -2,7 +2,7 @@
 
 [crates.io]: https://crates.io/crates/inquire-derive
 [latest version]: https://img.shields.io/crates/v/inquire-derive.svg
-[build status]: https://github.com/mikaelmello/inquire/actions/workflows/test.yml/badge.svg
+[build status]: https://github.com/mikaelmello/inquire/actions/workflows/build.yml/badge.svg
 [supported platforms]: https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-success
 [license]: https://img.shields.io/crates/l/inquire-derive.svg
 

--- a/inquire/CRATE_README.md
+++ b/inquire/CRATE_README.md
@@ -2,14 +2,14 @@
 
 [crates.io]: https://crates.io/crates/inquire
 [latest version]: https://img.shields.io/crates/v/inquire.svg
-[build status]: https://github.com/mikaelmello/inquire/actions/workflows/test.yml/badge.svg
+[build status]: https://github.com/mikaelmello/inquire/actions/workflows/build.yml/badge.svg
 [supported platforms]: https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-success
 [license]: https://img.shields.io/crates/l/inquire.svg
 
 ---
 
 <p align="center">
-  <img width="460" src="./assets/inquire.png">
+  <img width="460" src="../assets/inquire.png">
   <br>
   <code>inquire</code> is a library for building interactive prompts on terminals.
 </p>
@@ -29,7 +29,7 @@ It provides several different prompts in order to interactively ask the user for
 
 ## Demo
 
-![Animated GIF making a demonstration of a questionnaire created with this library. You can replay this recording in your terminal with asciinema play command - asciinema play ./assets/expense_tracker.cast](./assets/expense_tracker.gif)
+![Animated GIF making a demonstration of a questionnaire created with this library. You can replay this recording in your terminal with asciinema play command - asciinema play ../assets/expense_tracker.cast](../assets/expense_tracker.gif)
 [Source](./examples/expense_tracker.rs)
 
 ## Features
@@ -66,5 +66,5 @@ inquire = { version = "0.6.2", features = ["date", "editor"] }
 [`multiselect`]: https://docs.rs/inquire/*/inquire/prompts/multiselect/struct.MultiSelect.html
 [`confirm`]: https://docs.rs/inquire/*/inquire/prompts/confirm/struct.Confirm.html
 [`editor`]: https://docs.rs/inquire/*/inquire/prompts/editor/struct.Editor.html
-[`customtype`]: https://docs.rs/inquire/*/inquire/prompts/customtype/struct.CustomType.html
+[`customtype`]: https://docs.rs/inquire/*/inquire/struct.CustomType.html
 [`password`]: https://docs.rs/inquire/*/inquire/prompts/password/struct.Password.html


### PR DESCRIPTION
Was playing around with [lychee](https://github.com/lycheeverse/lychee/) and realised there were a couple of broken links.