### PR TITLE
Fix Clippy warning

### DIFF
--- a/inquire/src/prompts/multiselect/prompt.rs
+++ b/inquire/src/prompts/multiselect/prompt.rs
@@ -64,7 +64,7 @@ where
                     .filter(|i| *i < mso.options.len())
                     .collect()
             })
-            .unwrap_or_else(BTreeSet::new);
+            .unwrap_or_default();
 
         Ok(Self {
             message: mso.message,


### PR DESCRIPTION
The lint rule fails the CI checks for unrelated code changes in new PRs.