### PR TITLE
Fix render issue when using `console` crate as the terminal backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+- Fix render issue [#228](https://github.com/mikaelmello/inquire/pull/228) when using `console` crate as the terminal backend. Thanks @maospr for reporting.
 
 ## [0.7.0] - 2024-02-24
 

--- a/inquire/src/terminal/console.rs
+++ b/inquire/src/terminal/console.rs
@@ -91,7 +91,7 @@ impl Terminal for ConsoleTerminal {
     }
 
     fn clear_until_new_line(&mut self) -> Result<()> {
-        self.term.clear_to_end_of_screen()
+        write!(self.term, "\x1b[K")
     }
 
     fn cursor_hide(&mut self) -> Result<()> {


### PR DESCRIPTION
Fixes #228 