### PR TITLE
Add "cntl-D" to list of actions which cancel the current prompt session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+- Pressing Ctrl+D now cancels the prompt.
 
 ## [0.7.1] - 2024-03-10
 

--- a/inquire/src/prompts/action.rs
+++ b/inquire/src/prompts/action.rs
@@ -39,7 +39,9 @@ where
             Key::Enter
             | Key::Char('\n', KeyModifiers::NONE)
             | Key::Char('j', KeyModifiers::CONTROL) => Some(Action::Submit),
-            Key::Escape | Key::Char('g', KeyModifiers::CONTROL) => Some(Action::Cancel),
+            Key::Escape
+            | Key::Char('g', KeyModifiers::CONTROL)
+            | Key::Char('d', KeyModifiers::CONTROL) => Some(Action::Cancel),
             Key::Char('c', KeyModifiers::CONTROL) => Some(Action::Interrupt),
             key => I::from_key(key, config).map(Action::Inner),
         }


### PR DESCRIPTION
Also mentioned in https://github.com/mikaelmello/inquire/issues/224 that "cntl-d" is a common session-exit key combination. This PR adds it alongside 'escape' and 'cntl-g' (this is an odd one to cancel the session, by the way)