### PR TITLE
feat: MultiCount Interface

### DIFF
--- a/inquire/examples/multicount.rs
+++ b/inquire/examples/multicount.rs
@@ -1,0 +1,30 @@
+use inquire::{
+    formatter::MultiCountFormatter, list_option::ListOption, validator::Validation, MultiCount,
+};
+
+fn main() {
+    let options = vec![
+        "Banana",
+        "Apple",
+        "Strawberry",
+        "Grapes",
+        "Lemon",
+        "Tangerine",
+        "Watermelon",
+        "Orange",
+        "Pear",
+        "Avocado",
+        "Pineapple",
+    ];
+
+    let formatter: MultiCountFormatter<'_, &str> = &|a| format!("{} different fruits", a.len());
+
+    let ans = MultiCount::new("Select the fruits for your shopping list:", options)
+        .with_formatter(formatter)
+        .prompt();
+
+    match ans {
+        Ok(_) => println!("I'll get right on it"),
+        Err(_) => println!("The shopping list could not be processed"),
+    }
+}

--- a/inquire/src/formatter.rs
+++ b/inquire/src/formatter.rs
@@ -129,6 +129,8 @@ pub type OptionFormatter<'a, T> = &'a dyn Fn(ListOption<&T>) -> String;
 /// ```
 pub type MultiOptionFormatter<'a, T> = &'a dyn Fn(&[ListOption<&T>]) -> String;
 
+pub type MultiCountFormatter<'a, T> = &'a dyn Fn(&[(u32, ListOption<&T>)]) -> String;
+
 /// Type alias for formatters used in [`CustomType`](crate::CustomType) prompts.
 ///
 /// Formatters receive the user input and return a [String] to be displayed

--- a/inquire/src/prompts/mod.rs
+++ b/inquire/src/prompts/mod.rs
@@ -6,6 +6,7 @@ mod dateselect;
 #[cfg(feature = "editor")]
 mod editor;
 mod multiselect;
+mod multicount;
 mod one_liners;
 mod password;
 mod prompt;
@@ -22,6 +23,7 @@ pub use dateselect::*;
 #[cfg(feature = "editor")]
 pub use editor::*;
 pub use multiselect::*;
+pub use multicount::*;
 #[cfg(feature = "one-liners")]
 pub use one_liners::*;
 pub use password::*;

--- a/inquire/src/prompts/multicount/action.rs
+++ b/inquire/src/prompts/multicount/action.rs
@@ -1,0 +1,75 @@
+use crate::{ui::{Key, KeyModifiers}, InnerAction, InputAction};
+
+use super::config::MultiCountConfig;
+
+/// Set of actions for a MultiCountPrompt.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MultiCountPromptAction{
+    /// Action on the value text input handler.
+    FilterInput(InputAction),
+    /// Moves the cursor to the option above.
+    MoveUp,
+    /// Moves the cursor to the option below.
+    MoveDown,
+    /// Moves the cursor to the page above.
+    PageUp,
+    /// Moves the cursor to the page below.
+    PageDown,
+    /// Moves the cursor to the start of the list.
+    MoveToStart,
+    /// Moves the cursor to the end of the list.
+    MoveToEnd,
+    /// Toggles the selection of the current option.
+    SetCountCurrentOption(u32), 
+    /// Increments the current selection by one
+    Increment,
+    /// Decrements the current selection by one
+    Decrement,
+    /// Increments the current selection by the given amount
+    MultiIncrement(u32),
+    /// Decrements the current selection by the given amount
+    MultiDecrement(u32),
+    /// Clears counts for all options.
+    ClearSelections,
+}
+
+impl InnerAction for MultiCountPromptAction {
+    type Config = MultiCountConfig;
+
+    fn from_key(key: Key, config: &MultiCountConfig) -> Option<Self> {
+        if config.vim_mode {
+            let action = match key {
+                Key::Char('k', KeyModifiers::NONE) => Some(Self::MoveUp),
+                Key::Char('j', KeyModifiers::NONE) => Some(Self::MoveDown),
+                Key::Char('+', KeyModifiers::NONE) => Some(Self::Increment),
+                Key::Char('-', KeyModifiers::NONE) => Some(Self::Decrement),
+                _ => None,
+            };
+            if action.is_some() {
+                return action;
+            }
+        }
+    
+
+        let action = match key {
+            Key::Up(KeyModifiers::NONE) | Key::Char('p', KeyModifiers::CONTROL) => Self::MoveUp,
+
+            Key::PageUp(_) => Self::PageUp,
+            Key::Home => Self::MoveToStart,
+
+            Key::Down(KeyModifiers::NONE) | Key::Char('n', KeyModifiers::CONTROL) => Self::MoveDown,
+            Key::PageDown(_) => Self::PageDown,
+            Key::End => Self::MoveToEnd,
+
+            Key::Right(KeyModifiers::NONE) => Self::Increment,
+            Key::Left(KeyModifiers::NONE) => Self::Decrement,
+            Key::Right(KeyModifiers::SHIFT) => Self::MultiIncrement(10),
+            Key::Left(KeyModifiers::SHIFT) => Self::MultiDecrement(10),
+            key => match InputAction::from_key(key, &()) {
+                Some(action) => Self::FilterInput(action),
+                None => return None,
+            },
+         };
+         Some(action)
+    }
+}

--- a/inquire/src/prompts/multicount/config.rs
+++ b/inquire/src/prompts/multicount/config.rs
@@ -1,0 +1,25 @@
+use crate::MultiCount;
+
+/// Configuration settings used in the execution of a MultiCountPrompt.
+#[derive(Copy, Clone, Debug)]
+pub struct MultiCountConfig {
+    /// Whether to use vim-style keybindings.
+    pub vim_mode: bool,
+    /// Page size of the list of options.
+    pub page_size: usize,
+    /// Whether to keep the filter text when an option is selected.
+    pub keep_filter: bool,
+    /// Whether to reset the cursor to the first option on filter input change.
+    pub reset_cursor: bool,
+}
+
+impl<T> From<&MultiCount<'_, T>> for MultiCountConfig {
+    fn from(value: &MultiCount<'_, T>) -> Self {
+        Self {
+            vim_mode: value.vim_mode,
+            page_size: value.page_size,
+            keep_filter: value.keep_filter,
+            reset_cursor: value.reset_cursor,
+        }
+    }
+}

--- a/inquire/src/prompts/multicount/mod.rs
+++ b/inquire/src/prompts/multicount/mod.rs
@@ -1,0 +1,426 @@
+mod action;
+mod config;
+mod prompt;
+#[cfg(test)]
+#[cfg(feature = "crossterm")]
+mod test;
+
+pub use action::*;
+
+use std::fmt::Display;
+
+use crate::{
+        config::get_configuration,
+        error::{InquireError, InquireResult},
+        formatter::MultiCountFormatter,
+        list_option::ListOption,
+        prompts::prompt::Prompt,
+        terminal::get_default_terminal,
+        type_aliases::Scorer,
+        ui::{Backend, MultiCountBackend, RenderConfig},
+        validator::MultiOptionValidator,
+    };
+
+use self::prompt::MultiCountPrompt;
+
+#[cfg(feature = "fuzzy")]
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+#[cfg(feature = "fuzzy")]
+use once_cell::sync::Lazy;
+#[cfg(feature = "fuzzy")]
+static DEFAULT_MATCHER: Lazy<SkimMatcherV2> = Lazy::new(|| SkimMatcherV2::default().ignore_case());
+/// Prompt suitable for when you need the user to select counts of multiple options (including none if applicable) among a list of them.
+///
+/// The user can begin choosing a count for the current highlighted option by pressing spac.
+///
+/// This prompt requires a prompt message and a **non-empty** `Vec` of options to be displayed to the user. The options can be of any type as long as they implement the `Display` trait. It is required that the `Vec` is moved to the prompt, as the prompt will return the ownership of the `Vec` after the user submits, with only the selected options inside it.
+/// - If the list is empty, the prompt operation will fail with an `InquireError::InvalidConfiguration` error.
+///
+/// The options are paginated in order to provide a smooth experience to the user, with the default page size being 7. The user can move from the options and the pages will be updated accordingly, including moving from the last to the first options (or vice-versa).
+///
+/// Customizable options:
+///
+/// - **Prompt message**: Required when creating the prompt.
+/// - **Options list**: Options displayed to the user. Must be **non-empty**.
+/// - **Default counts**: Counts for options by default when the prompt is first rendered. The use can zero them.
+/// - **Starting cursor**: Index of the cursor when the prompt is first rendered. Default is 0 (first option). If the index is out-of-range of the option list, the prompt will fail with an [`InquireError::InvalidConfiguration`] error.
+/// - **Starting filter input**: Sets the initial value of the filter section of the prompt.
+/// - **Help message**: Message displayed at the line below the prompt.
+/// - **Formatter**: Custom formatter in case you need to pre-process the user input before showing it as the final answer.
+///   - Prints the selected options string value, joined using a comma as the separator, by default.
+/// - **Validator**: Custom validator to make sure a given submitted input pass the specified requirements, e.g. not allowing 0 selected options or limiting the number of options that the user is allowed to select.
+///   - No validators are on by default.
+/// - **Page size**: Number of options displayed at once, 7 by default.
+/// - **Display option indexes**: On long lists, it might be helpful to display the indexes of the options to the user. Via the `RenderConfig`, you can set the display mode of the indexes as a prefix of an option. The default configuration is `None`, to not render any index when displaying the options.
+/// - **Scorer function**: Function that defines the order of options and if displayed as all.
+/// - **Keep filter flag**: Whether the current filter input should be cleared or not after a selection is made. Defaults to true.
+///
+/// # Example
+///
+/// For a full-featured example, check the [GitHub repository](https://github.com/mikaelmello/inquire/blob/main/examples/multiselect.rs).
+///
+/// [`InquireError::InvalidConfiguration`]: crate::error::InquireError::InvalidConfiguration
+#[derive(Clone)]
+pub struct MultiCount<'a, T> {
+    /// Message to be presented to the user.
+    pub message: &'a str,
+
+    /// Options displayed to the user.
+    pub options: Vec<T>,
+
+    /// Default indexes of options to be selected from the start.
+    pub default: Option<Vec<(usize, u32)>>,
+
+    /// Help message to be presented to the user.
+    pub help_message: Option<&'a str>,
+
+    /// Page size of the options displayed to the user.
+    pub page_size: usize,
+
+    /// Whether vim mode is enabled. When enabled, the user can
+    /// navigate through the options using hjkl.
+    pub vim_mode: bool,
+
+    /// Starting cursor index of the selection.
+    pub starting_cursor: usize,
+
+    /// Starting filter input
+    pub starting_filter_input: Option<&'a str>,
+
+    /// Reset cursor position to first option on filter input change.
+    /// Defaults to true.
+    pub reset_cursor: bool,
+
+    /// Whether to allow the option list to be filtered by user input or not.
+    ///
+    /// Defaults to true.
+    pub filter_input_enabled: bool,
+
+    /// Function called with the current user input to score the provided
+    /// options.
+    /// The list of options is sorted in descending order (highest score first)
+    pub scorer: Scorer<'a, T>,
+
+    /// Whether the current filter typed by the user is kept or cleaned after a selection is made.
+    pub keep_filter: bool,
+
+    /// Function that formats the user input and presents it to the user as the final rendering of the prompt.
+    pub formatter: MultiCountFormatter<'a, T>,
+
+    /// Validator to apply to the user input.
+    ///
+    /// In case of error, the message is displayed one line above the prompt.
+    pub validator: Option<Box<dyn MultiOptionValidator<T>>>,
+
+    /// RenderConfig to apply to the rendered interface.
+    ///
+    /// Note: The default render config considers if the NO_COLOR environment variable
+    /// is set to decide whether to render the colored config or the empty one.
+    ///
+    /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
+    /// config is treated as the only source of truth. If you want to customize colors
+    /// and still support NO_COLOR, you will have to do this on your end.
+    pub render_config: RenderConfig<'a>,
+}
+
+impl<'a, T> MultiCount<'a, T>
+where
+    T: Display,
+{
+    /// String formatter used by default in [MultiSelect](crate::MultiSelect) prompts.
+    /// Prints the string value of all selected options, separated by commas.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inquire::list_option::ListOption;
+    /// use inquire::MultiSelect;
+    ///
+    /// let formatter = MultiSelect::<&str>::DEFAULT_FORMATTER;
+    ///
+    /// let mut ans = vec![ListOption::new(0, &"New York")];
+    /// assert_eq!(String::from("New York"), formatter(&ans));
+    ///
+    /// ans.push(ListOption::new(3, &"Seattle"));
+    /// assert_eq!(String::from("New York, Seattle"), formatter(&ans));
+    ///
+    /// ans.push(ListOption::new(7, &"Vancouver"));
+    /// assert_eq!(String::from("New York, Seattle, Vancouver"), formatter(&ans));
+    /// ```
+    pub const DEFAULT_FORMATTER: MultiCountFormatter<'a, T> = &|ans| {
+        ans.iter()
+            .map(|(c, opt)| format!("{}: {}", opt, c))
+            .collect::<Vec<String>>()
+            .join(", ")
+    };
+
+    /// Default scoring function, which will create a score for the current option using the input value.
+    /// The return will be sorted in Descending order, leaving options with None as a score.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inquire::MultiSelect;
+    ///
+    /// let scorer = MultiSelect::<&str>::DEFAULT_SCORER;
+    /// assert_eq!(None,     scorer("sa", &"New York",      "New York",      0));
+    /// assert_eq!(Some(49), scorer("sa", &"Sacramento",    "Sacramento",    1));
+    /// assert_eq!(Some(35), scorer("sa", &"Kansas",        "Kansas",        2));
+    /// assert_eq!(Some(35), scorer("sa", &"Mesa",          "Mesa",          3));
+    /// assert_eq!(None,     scorer("sa", &"Phoenix",       "Phoenix",       4));
+    /// assert_eq!(None,     scorer("sa", &"Philadelphia",  "Philadelphia",  5));
+    /// assert_eq!(Some(49), scorer("sa", &"San Antonio",   "San Antonio",   6));
+    /// assert_eq!(Some(49), scorer("sa", &"San Diego",     "San Diego",     7));
+    /// assert_eq!(None,     scorer("sa", &"Dallas",        "Dallas",        8));
+    /// assert_eq!(Some(49), scorer("sa", &"San Francisco", "San Francisco", 9));
+    /// assert_eq!(None,     scorer("sa", &"Austin",        "Austin",        10));
+    /// assert_eq!(None,     scorer("sa", &"Jacksonville",  "Jacksonville",  11));
+    /// assert_eq!(Some(49), scorer("sa", &"San Jose",      "San Jose",      12));
+    /// ```
+    #[cfg(feature = "fuzzy")]
+    pub const DEFAULT_SCORER: Scorer<'a, T> =
+        &|input, _option, string_value, _idx| -> Option<i64> {
+            DEFAULT_MATCHER.fuzzy_match(string_value, input)
+        };
+
+    #[cfg(not(feature = "fuzzy"))]
+    pub const DEFAULT_SCORER: Scorer<'a, T> =
+        &|input, _option, string_value, _idx| -> Option<i64> {
+            let filter = input.to_lowercase();
+            match string_value.to_lowercase().contains(&filter) {
+                true => Some(0),
+                false => None,
+            }
+        };
+
+    /// Default page size, equal to the global default page size [config::DEFAULT_PAGE_SIZE]
+    pub const DEFAULT_PAGE_SIZE: usize = crate::config::DEFAULT_PAGE_SIZE;
+
+    /// Default value of vim mode, equal to the global default value [config::DEFAULT_PAGE_SIZE]
+    pub const DEFAULT_VIM_MODE: bool = crate::config::DEFAULT_VIM_MODE;
+
+    /// Default starting cursor index.
+    pub const DEFAULT_STARTING_CURSOR: usize = 0;
+
+    /// Default cursor behaviour on filter input change.
+    /// Defaults to true.
+    pub const DEFAULT_RESET_CURSOR: bool = true;
+
+    /// Default filter input enabled behaviour.
+    /// Defaults to true.
+    pub const DEFAULT_FILTER_INPUT_ENABLED: bool = true;
+
+    /// Default behavior of keeping or cleaning the current filter value.
+    pub const DEFAULT_KEEP_FILTER: bool = true;
+
+    /// Default help message.
+    pub const DEFAULT_HELP_MESSAGE: Option<&'a str> =
+        Some("↑↓ to move, → to increment, ← to decrement, shift + → to increment by ten, shift + ← to decrement, type to filter");
+
+    /// Creates a [MultiCount] with the provided message and options, along with default configuration values.
+    pub fn new(message: &'a str, options: Vec<T>) -> Self {
+        Self {
+            message,
+            options,
+            default: None,
+            help_message: Self::DEFAULT_HELP_MESSAGE,
+            page_size: Self::DEFAULT_PAGE_SIZE,
+            vim_mode: Self::DEFAULT_VIM_MODE,
+            starting_cursor: Self::DEFAULT_STARTING_CURSOR,
+            starting_filter_input: None,
+            reset_cursor: Self::DEFAULT_RESET_CURSOR,
+            filter_input_enabled: Self::DEFAULT_FILTER_INPUT_ENABLED,
+            keep_filter: Self::DEFAULT_KEEP_FILTER,
+            scorer: Self::DEFAULT_SCORER,
+            formatter: Self::DEFAULT_FORMATTER,
+            validator: None,
+            render_config: get_configuration(),
+        }
+    }
+
+    /// Sets the help message of the prompt.
+    pub fn with_help_message(mut self, message: &'a str) -> Self {
+        self.help_message = Some(message);
+        self
+    }
+
+    /// Removes the set help message.
+    pub fn without_help_message(mut self) -> Self {
+        self.help_message = None;
+        self
+    }
+
+    /// Sets the page size.
+    pub fn with_page_size(mut self, page_size: usize) -> Self {
+        self.page_size = page_size;
+        self
+    }
+
+    /// Enables or disables vim_mode.
+    pub fn with_vim_mode(mut self, vim_mode: bool) -> Self {
+        self.vim_mode = vim_mode;
+        self
+    }
+
+    /// Sets the keep filter behavior.
+    pub fn with_keep_filter(mut self, keep_filter: bool) -> Self {
+        self.keep_filter = keep_filter;
+        self
+    }
+
+    /// Sets the scoring function.
+    pub fn with_scorer(mut self, scorer: Scorer<'a, T>) -> Self {
+        self.scorer = scorer;
+        self
+    }
+
+    /// Sets the formatter.
+    pub fn with_formatter(mut self, formatter: MultiCountFormatter<'a, T>) -> Self {
+        self.formatter = formatter;
+        self
+    }
+
+    /// Sets the validator to apply to the user input. You might want to use this feature
+    /// in case you need to limit the user to specific choices, such as limiting the number
+    /// of selections.
+    ///
+    /// In case of error, the message is displayed one line above the prompt.
+    pub fn with_validator<V>(mut self, validator: V) -> Self
+    where
+        V: MultiOptionValidator<T> + 'static,
+    {
+        self.validator = Some(Box::new(validator));
+        self
+    }
+
+    /// Sets the indexes to be selected by default.
+    ///
+    /// The values should be valid indexes for the given option list. Any
+    /// numbers larger than the option list or duplicates will be ignored.
+    pub fn with_default(mut self, default: &'a [(usize, u32)]) -> Self {
+        self.default = Some(default.to_vec());
+        self
+    }
+
+    /// Sets all options to be selected by default.
+    /// This overrides any previously set default and is equivalent to calling
+    /// `with_default` with a slice containing all indexes for the given
+    /// option list.
+    pub fn with_all_one_by_default(mut self) -> Self {
+        self.default = Some((0..self.options.len()).map(|i| (i, 0)).collect::<Vec<_>>());
+        self
+    }
+
+    /// Sets the starting cursor index.
+    ///
+    /// This index might be overridden if the `reset_cursor` option is set to true (default)
+    /// and starting_filter_input is set to something other than None.
+    pub fn with_starting_cursor(mut self, starting_cursor: usize) -> Self {
+        self.starting_cursor = starting_cursor;
+        self
+    }
+
+    /// Sets the starting filter input
+    pub fn with_starting_filter_input(mut self, starting_filter_input: &'a str) -> Self {
+        self.starting_filter_input = Some(starting_filter_input);
+        self
+    }
+
+    /// Sets the reset_cursor behaviour. Defaults to true.
+    ///
+    /// When there's an input change that results in a different list of options being displayed,
+    /// whether by filtering or re-ordering, the cursor will be reset to highlight the first option.
+    pub fn with_reset_cursor(mut self, reset_cursor: bool) -> Self {
+        self.reset_cursor = reset_cursor;
+        self
+    }
+
+    /// Disables the filter input, which means the user will not be able to filter the options
+    /// by typing.
+    ///
+    /// This is useful when you want to simplify the UX if the filter does not add any value,
+    /// such as when the list is already short.
+    pub fn without_filtering(mut self) -> Self {
+        self.filter_input_enabled = false;
+        self
+    }
+
+    /// Sets the provided color theme to this prompt.
+    ///
+    /// Note: The default render config considers if the NO_COLOR environment variable
+    /// is set to decide whether to render the colored config or the empty one.
+    ///
+    /// When overriding the config in a prompt, NO_COLOR is no longer considered and your
+    /// config is treated as the only source of truth. If you want to customize colors
+    /// and still support NO_COLOR, you will have to do this on your end.
+    pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
+        self.render_config = render_config;
+        self
+    }
+
+    /// Parses the provided behavioral and rendering options and prompts
+    /// the CLI user for input according to the defined rules.
+    ///
+    /// Returns the owned objects selected by the user.
+    ///
+    /// This method is intended for flows where the user skipping/cancelling
+    /// the prompt - by pressing ESC - is considered normal behavior. In this case,
+    /// it does not return `Err(InquireError::OperationCanceled)`, but `Ok(None)`.
+    ///
+    /// Meanwhile, if the user does submit an answer, the method wraps the return
+    /// type with `Some`.
+    pub fn prompt_skippable(self) -> InquireResult<Option<Vec<(u32, T)>>> {
+        match self.prompt() {
+            Ok(answer) => Ok(Some(answer)),
+            Err(InquireError::OperationCanceled) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Parses the provided behavioral and rendering options and prompts
+    /// the CLI user for input according to the defined rules.
+    ///
+    /// Returns the owned objects selected by the user.
+    pub fn prompt(self) -> InquireResult<Vec<(u32, T)>> {
+        self.raw_prompt()
+            .map(|op| op.into_iter().map(|(c, o)| (c, o.value)).collect())
+    }
+
+    /// Parses the provided behavioral and rendering options and prompts
+    /// the CLI user for input according to the defined rules.
+    ///
+    /// Returns a vector of [`ListOption`](crate::list_option::ListOption)s containing
+    /// the index of the selections and the owned objects selected by the user.
+    ///
+    /// This method is intended for flows where the user skipping/cancelling
+    /// the prompt - by pressing ESC - is considered normal behavior. In this case,
+    /// it does not return `Err(InquireError::OperationCanceled)`, but `Ok(None)`.
+    ///
+    /// Meanwhile, if the user does submit an answer, the method wraps the return
+    /// type with `Some`.
+    pub fn raw_prompt_skippable(self) -> InquireResult<Option<Vec<(u32, ListOption<T>)>>> {
+        match self.raw_prompt() {
+            Ok(answer) => Ok(Some(answer)),
+            Err(InquireError::OperationCanceled) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Parses the provided behavioral and rendering options and prompts
+    /// the CLI user for input according to the defined rules.
+    ///
+    /// Returns a [`ListOption`](crate::list_option::ListOption) containing
+    /// the index of the selection and the owned object selected by the user.
+    pub fn raw_prompt(self) -> InquireResult<Vec<(u32, ListOption<T>)>> {
+        let (input_reader, terminal) = get_default_terminal()?;
+        let mut backend = Backend::new(input_reader, terminal, self.render_config)?;
+        self.prompt_with_backend(&mut backend)
+    }
+
+    pub(crate) fn prompt_with_backend<B: MultiCountBackend>(
+        self,
+        backend: &mut B,
+    ) -> InquireResult<Vec<(u32, ListOption<T>)>> {
+        MultiCountPrompt::new(self)?.prompt(backend)
+    }
+}

--- a/inquire/src/prompts/multicount/prompt.rs
+++ b/inquire/src/prompts/multicount/prompt.rs
@@ -1,0 +1,385 @@
+use std::{cmp::Reverse, collections::BTreeSet, fmt::Display};
+
+use crate::{
+    error::InquireResult,
+    formatter::MultiCountFormatter,
+    input::{Input, InputActionResult},
+    list_option::ListOption,
+    prompts::prompt::{ActionResult, Prompt},
+    type_aliases::Scorer,
+    ui::MultiCountBackend,
+    utils::paginate,
+    validator::{ErrorMessage, MultiOptionValidator, Validation},
+    InquireError, MultiCount,
+};
+
+use super::{action::MultiCountPromptAction, config::MultiCountConfig};
+
+pub struct MultiCountPrompt<'a, T> {
+    message: &'a str,
+    config: MultiCountConfig,
+    options: Vec<T>,
+    string_options: Vec<String>,
+    help_message: Option<&'a str>,
+    cursor_index: usize,
+    counts: BTreeSet<(usize, u32)>, // Likely records which ones are checked...?
+    input: Option<Input>,
+    scored_options: Vec<usize>,
+    scorer: Scorer<'a, T>,
+    formatter: MultiCountFormatter<'a, T>,
+    validator: Option<Box<dyn MultiOptionValidator<T>>>,
+    error: Option<ErrorMessage>,
+}
+
+impl <'a, T> MultiCountPrompt<'a, T>
+where
+    T: Display,
+{
+    pub fn new(mco: MultiCount<'a, T>) -> InquireResult<Self> {
+        if mco.options.is_empty() {
+            return Err(InquireError::InvalidConfiguration(
+                "Must have at least one available option".into(),
+            ));
+        }
+
+        // Check if the default is within bounds 
+        if let Some(default) = &mco.default { // i.e. if it has a default
+            for (i, _) in default {
+                if i >= &mco.options.len() {
+                    return Err(InquireError::InvalidConfiguration(
+                        format!("Index {} is out-of-bounds for length {} of options", i, &mco.options.len())
+                        ));
+                }
+            }
+        }
+        let string_options = mco
+            .options
+            .iter()
+            .map(T::to_string)
+            .collect(); // get the string representation of the options
+
+        let scored_options = (0..mco.options.len()).collect(); // get the indices of the options
+        let option_counts = mco
+            .default
+            .as_ref()
+            .map(|d| {
+                d.iter()
+                    .cloned()
+                    .filter(|(i, _)| *i < mco.options.len())
+                    .collect()
+                })
+        .unwrap_or_default();
+
+        let input = match mco.filter_input_enabled {
+            true => Some(Input::new_with(
+                    mco.starting_filter_input.unwrap_or_default(),
+                )),
+                false => None,
+        };
+
+        Ok(Self {
+            message: mco.message,
+            config: (&mco).into(),
+            options: mco.options,
+            string_options,
+            scored_options,
+            help_message: mco.help_message,
+            cursor_index: mco.starting_cursor,
+            input,
+            scorer: mco.scorer,
+            formatter: mco.formatter,
+            validator: mco.validator,
+            error: None,
+            counts: option_counts,
+        })
+        }
+
+         
+
+        fn move_cursor_up(&mut self, qty: usize, wrap: bool) -> ActionResult {
+            let new_position = if wrap {
+                let after_wrap = qty.saturating_sub(self.cursor_index);
+                self.cursor_index.checked_sub(qty).unwrap_or_else(|| self.scored_options.len().saturating_sub(after_wrap))
+            } else{
+                self.cursor_index.saturating_sub(qty)
+            };
+
+            self.update_cursor_position(new_position)
+        }
+
+        fn move_cursor_down(&mut self, qty: usize, wrap: bool) -> ActionResult {
+            let mut new_position = self.cursor_index.saturating_add(qty);
+
+            if new_position >= self.scored_options.len() {
+                new_position = if self.scored_options.is_empty() {
+                    0
+                } else if wrap {
+                    new_position % self.scored_options.len()
+                } else {
+                    self.scored_options.len().saturating_sub(1)
+                }
+            }
+
+            self.update_cursor_position(new_position)
+        }
+
+        fn update_cursor_position(&mut self, new_position: usize) -> ActionResult {
+            if new_position != self.cursor_index {
+                self.cursor_index = new_position;
+                ActionResult::NeedsRedraw
+            } else {
+                ActionResult::Clean
+            }
+        }
+
+        fn set_value(&mut self, qty: u32) -> ActionResult {
+            // get the id of the currently selected option, if it exists
+            let idx = match self.scored_options.get(self.cursor_index) {
+                Some(idx) => idx,
+                None => return ActionResult::Clean,
+            };
+            self.counts.insert((*idx, qty));
+            ActionResult::NeedsRedraw
+        }
+
+        fn alter_value(&mut self, diff: i32) -> ActionResult {
+            let idx = match self.scored_options.get(self.cursor_index) {
+                Some(idx) => idx,
+                None => return ActionResult::Clean,
+            };
+
+            let current_val = self.counts
+                .iter()
+                .find(|(i, _)| i == idx);
+            let old_val;
+            let new_val;
+                
+            match current_val {
+                    // At the beginning, the tree is empty.
+                    // if the value is not in the tree, we insert it at a value of 1.
+                    None => { // because zero-vals are removed from the btree, we need to
+                        // jump-start with a basic value
+                        if diff > 0 {
+                            self.counts.insert((*idx, diff as u32));
+                        }
+                    }
+                    // i.e. if it finds the pair
+                    Some((_, c)) => {
+                        old_val = *c;
+                        if diff < 0 {
+                            new_val = (*c).saturating_sub(-diff as u32);
+                        } else {
+                            new_val = (*c).saturating_add(diff as u32);
+                        }
+                        self.counts.insert((*idx, new_val));
+                        self.counts.remove(&(*idx, old_val));
+                    }
+                }
+            ActionResult::NeedsRedraw
+        }
+
+        fn clear_input_if_needed(&mut self, action: MultiCountPromptAction) -> ActionResult {
+            if !self.config.keep_filter {
+                return ActionResult::Clean;
+            }
+
+            match action {
+                MultiCountPromptAction::SetCountCurrentOption(_)
+                | MultiCountPromptAction::ClearSelections => {
+                    self.input.as_mut().map(Input::clear);
+                    ActionResult::NeedsRedraw
+                }
+                _ => ActionResult::Clean,
+            }
+        }
+
+        // Used to validate the the current "answer" is valid.
+        fn validate_current_answer(&self) -> InquireResult<Validation> {
+            if let Some(validator) = &self.validator {
+                // for each of the options, create a list option if the number is positive
+                let mut option_counts = vec![];
+                for (idx, count) in &self.counts {
+                    if *count > 0 {
+                        let value = self.options.get(*idx).unwrap();
+                        let lo = ListOption::new(*idx, value);
+                        option_counts.push(lo);
+                    }
+                }                     
+
+
+                let res = validator.validate(&option_counts)?;
+                Ok(res)
+            } else {
+                Ok(Validation::Valid)
+            }
+        }
+
+        /// used to produce the actual vector of type values
+        /// THIS IS WRONG AT THE MOMENT: NEED TO SEE WHAT IS GIONG ON WITH self.OPTIONS
+        fn get_final_answer(&mut self) -> Vec<(u32, ListOption<T>)> {
+            let mut answer = vec![];
+
+            // by iterating in descending order, we can safely
+            // swap remove because the elements to the right
+            // that we did not remove will not matter anymore.
+            for pair in self.counts.iter().filter(|(_, val)| val>&0).rev() {
+                let index = pair.0;
+                let count = pair.1;
+                let value = self.options.swap_remove(index);
+                let lo = (count, ListOption::new(index, value));
+                answer.push(lo);
+            }
+            answer.reverse();
+
+            answer
+        }
+
+        /// This seems ok in terms of operation 18/03/2024 - no apparent dependence
+        /// on the fact that it's counts not checks
+        fn run_scorer(&mut self) {
+            let content = match &self.input {
+                Some(input) => input.content(),
+                None => return,
+            };
+            // apply the scorer to the content and the options, map to a vec
+            // of score and index
+            let mut options = self
+                .options
+                .iter()
+                .enumerate()
+                .filter_map(|(i, opt)| {
+                    (self.scorer)(content, opt, self.string_options.get(i).unwrap(), i)
+                        .map(|score| (i, score))
+                })
+                .collect::<Vec<(usize, i64)>>();
+        
+
+            // sort the options by the score
+            options.sort_unstable_by_key(|(_idx, score)| Reverse(*score));
+
+            let new_scored_options = options
+                .iter()
+                .map(|(idx, _)| *idx)
+                .collect::<Vec<usize>>();
+
+            if self.scored_options == new_scored_options {
+                return;
+            }
+
+            self.scored_options = new_scored_options;
+
+            if self.config.reset_cursor {
+                let _ = self.update_cursor_position(0);
+            } else if self.scored_options.len() <= self.cursor_index {
+                let _ = self.update_cursor_position(self.scored_options.len().saturating_sub(1));
+            }
+        }
+
+}
+
+impl <'a, Backend, T> Prompt<Backend> for MultiCountPrompt<'a, T>
+where Backend: MultiCountBackend,
+      T:Display,
+{
+    type Config = MultiCountConfig;
+    type InnerAction = MultiCountPromptAction;
+    type Output = Vec<(u32, ListOption<T>)>;
+    fn message(&self) -> &str {
+        self.message
+    }
+    fn config(&self) -> &MultiCountConfig {
+        &self.config
+    }
+    fn format_answer(&self, answer: &Vec<(u32, ListOption<T>)>) -> String {
+        let refs: Vec<(u32, ListOption<&T>)> = answer
+            .iter()
+            .map(|(c, l)| (*c, ListOption::as_ref(l)))
+            .collect();
+        (self.formatter)(&refs)
+    }
+
+    fn setup(&mut self) -> InquireResult<()> {
+        self.run_scorer();
+        Ok(())
+    }
+
+    fn submit(&mut self) -> InquireResult<Option<Vec<(u32, ListOption<T>)>>> {
+        let answer = match self.validate_current_answer()? {
+            Validation::Valid => Some(self.get_final_answer()),
+            Validation::Invalid(msg) => {
+                self.error = Some(msg);
+                None
+            }
+        };
+
+        Ok(answer)
+    }
+
+    /// appears to be the implementation of the actual actions written in action.rs
+    fn handle(&mut self, action: MultiCountPromptAction) -> InquireResult<ActionResult> {
+        let result = match action {
+            MultiCountPromptAction::MoveUp => self.move_cursor_up(1, true),
+            MultiCountPromptAction::MoveDown => self.move_cursor_down(1, true),
+            MultiCountPromptAction::PageUp => self.move_cursor_up(self.config.page_size, false),
+            MultiCountPromptAction::PageDown => {
+                self.move_cursor_down(self.config.page_size, false)
+            }
+            MultiCountPromptAction::MoveToStart => self.move_cursor_up(usize::MAX, false),
+            MultiCountPromptAction::MoveToEnd => self.move_cursor_down(usize::MAX, false),
+            //MultiCountPromptAction::ToggleCurrentOption => self.toggle_cursor_selection(),
+            MultiCountPromptAction::Increment => self.alter_value(1),
+            MultiCountPromptAction::Decrement => self.alter_value(-1),
+            MultiCountPromptAction::MultiIncrement(qty) => self.alter_value(qty as i32),
+            MultiCountPromptAction::MultiDecrement(qty) => self.alter_value(-(qty as i32)),
+            MultiCountPromptAction::SetCountCurrentOption(qty) => self.set_value(qty),
+            MultiCountPromptAction::ClearSelections => {
+                self.counts.clear();
+                ActionResult::NeedsRedraw
+            }
+            MultiCountPromptAction::FilterInput(input_action) => match self.input.as_mut() {
+                Some(input) => {
+                    let result = input.handle(input_action);
+
+                    if let InputActionResult::ContentChanged = result {
+                        self.run_scorer();
+                    }
+
+                    result.into()
+                }
+                None => ActionResult::Clean,
+            },
+        };
+
+        let result = self.clear_input_if_needed(action).merge(result);
+
+        Ok(result)
+    }
+
+    fn render(&self, backend: &mut Backend) -> InquireResult<()> {
+        let prompt = &self.message;
+
+        if let Some(err) = &self.error {
+            backend.render_error_message(err)?;
+        }
+
+        backend.render_multiselect_prompt(prompt, self.input.as_ref())?;
+
+        let choices = self
+            .scored_options
+            .iter()
+            .cloned()
+            .map(|i| ListOption::new(i, self.options.get(i).unwrap()))
+            .collect::<Vec<ListOption<&T>>>();
+
+        let page = paginate(self.config.page_size, &choices, Some(self.cursor_index));
+
+        backend.render_options(page, &self.counts)?;
+
+        if let Some(help_message) = self.help_message {
+            backend.render_help_message(help_message)?;
+        }
+
+        Ok(())
+    }
+}
+

--- a/inquire/src/prompts/multicount/test.rs
+++ b/inquire/src/prompts/multicount/test.rs
@@ -1,0 +1,147 @@
+use crate::{
+    formatter::MultiCountFormatter,
+    list_option::ListOption,
+    test::fake_backend,
+    ui::{Key, KeyModifiers},
+    MultiCount,
+};
+
+#[test]
+/// Tests that a closure that actually closes on a variable can be used
+/// as a Select formatter.
+fn closure_formatter() {
+    let mut backend = fake_backend(vec![Key::Right(KeyModifiers::NONE), Key::Enter]);
+
+    let formatted = String::from("Thanks!");
+    let formatter: MultiCountFormatter<'_, &str> = &|_| formatted.clone();
+
+    let options = vec!["one", "two", "three"];
+
+    let ans = MultiCount::new("Question", options)
+        .with_formatter(formatter)
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(vec![(1, ListOption::new(0, "one"))], ans);
+}
+
+#[test]
+// Anti-regression test: https://github.com/mikaelmello/inquire/issues/30
+fn down_arrow_on_empty_list_does_not_panic() {
+    let mut backend = fake_backend(vec![
+        Key::Char('9', KeyModifiers::NONE),
+        Key::Down(KeyModifiers::NONE),
+        Key::Backspace,
+        Key::Char('3', KeyModifiers::NONE),
+        Key::Down(KeyModifiers::NONE),
+        Key::Backspace,
+        Key::Enter,
+    ]);
+
+    let options = vec![1, 2, 3];
+
+    let ans = MultiCount::new("Question", options)
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(Vec::<(u32, ListOption<i32>)>::new(), ans);
+}
+
+#[test]
+// Anti-regression test: https://github.com/mikaelmello/inquire/issues/31
+fn list_option_indexes_are_relative_to_input_vec() {
+    let mut backend = fake_backend(vec![
+        Key::Down(KeyModifiers::NONE),
+        Key::Right(KeyModifiers::NONE),
+        Key::Down(KeyModifiers::NONE),
+        Key::Right(KeyModifiers::SHIFT),
+        Key::Enter,
+    ]);
+
+    let options = vec![1, 2, 3];
+
+    let ans = MultiCount::new("Question", options)
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(vec![(1, ListOption::new(1, 2)), (10, ListOption::new(2, 3))], ans);
+}
+
+#[test]
+// Anti-regression test: https://github.com/mikaelmello/inquire/issues/195
+fn starting_cursor_is_respected() {
+    let mut backend = fake_backend(vec![Key::Right(KeyModifiers::NONE), Key::Enter]);
+    let options = vec![1, 2, 3];
+
+    let ans = MultiCount::new("Question", options)
+        .with_starting_cursor(2)
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(vec![(1, ListOption::new(2, 3))], ans);
+}
+
+#[test]
+fn naive_assert_fuzzy_match_as_default_scorer() {
+    let mut backend = fake_backend(vec![
+        Key::Char('w', KeyModifiers::NONE),
+        Key::Char('r', KeyModifiers::NONE),
+        Key::Char('r', KeyModifiers::NONE),
+        Key::Char('y', KeyModifiers::NONE),
+        Key::Right(KeyModifiers::NONE),
+        Key::Enter,
+    ]);
+
+    let options = vec![
+        "Banana",
+        "Apple",
+        "Strawberry",
+        "Grapes",
+        "Lemon",
+        "Tangerine",
+        "Watermelon",
+        "Orange",
+        "Pear",
+        "Avocado",
+        "Pineapple",
+    ];
+
+    let ans = MultiCount::new("Question", options)
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(vec![(1, ListOption::new(2, "Strawberry"))], ans);
+}
+
+#[test]
+fn chars_do_not_affect_prompt_without_filtering() {
+    let mut backend = fake_backend(vec![
+        Key::Char('w', KeyModifiers::NONE),
+        Key::Char('r', KeyModifiers::NONE),
+        Key::Char('r', KeyModifiers::NONE),
+        Key::Char('y', KeyModifiers::NONE),
+        Key::Right(KeyModifiers::NONE),
+        Key::Enter,
+    ]);
+
+    let options = vec![
+        "Banana",
+        "Apple",
+        "Strawberry",
+        "Grapes",
+        "Lemon",
+        "Tangerine",
+        "Watermelon",
+        "Orange",
+        "Pear",
+        "Avocado",
+        "Pineapple",
+    ];
+
+    let ans = MultiCount::new("Question", options)
+        .without_filtering()
+        .prompt_with_backend(&mut backend)
+        .unwrap();
+
+    assert_eq!(vec![(1, ListOption::new(0, "Banana"))], ans);
+}

--- a/inquire/src/ui/backend.rs
+++ b/inquire/src/ui/backend.rs
@@ -51,6 +51,13 @@ pub trait MultiSelectBackend: CommonBackend {
         checked: &BTreeSet<usize>,
     ) -> Result<()>;
 }
+ pub trait MultiCountBackend: CommonBackend {
+     fn render_multiselect_prompt(&mut self, prompt: &str, cur_input: Option<&Input>) -> Result<()>;
+     fn render_options<D: Display>(
+         &mut self,
+         page: Page<'_, ListOption<D>>,
+         counts: &BTreeSet<(usize, u32)>) -> Result<()>;
+ }
 
 pub trait CustomTypeBackend: CommonBackend {
     fn render_prompt(
@@ -446,6 +453,61 @@ where
 
         Ok(())
     }
+}
+
+impl <'a, I, T> MultiCountBackend for Backend<'a, I, T>
+where
+    I: InputReader,
+    T:Terminal,
+{
+    fn render_multiselect_prompt(&mut self, prompt: &str, cur_input: Option<&Input>) -> Result<()> {
+        if let Some(input) = cur_input {
+            self.print_prompt_with_input(prompt, None, input)
+        } else {
+            self.print_prompt(prompt)
+        }
+    }
+    fn render_options<D: Display>(
+        &mut self,
+        page: Page<'_, ListOption<D>>,
+        counts: &BTreeSet<(usize, u32)>,
+    ) -> Result<()> {
+        for (idx, option) in page.content.iter().enumerate() {
+            self.print_option_prefix(idx, &page)?;
+
+            self.frame_renderer.write(" ")?;
+
+            if let Some(res) = self.print_option_index_prefix(option.index, page.total) {
+                res?;
+                self.frame_renderer.write(" ")?;
+            }
+
+            // pull out the count and build the countbox text
+            let count = counts
+                .iter()
+                .find(|(i, _)| i == &option.index)
+                .map(|(_, c)| c)
+                .unwrap_or(&0);
+            let mut countbox = Styled::new(format!("[{}]", count));
+
+
+            match (self.render_config.selected_option, page.cursor) {
+                (Some(stylesheet), Some(cursor)) if cursor == idx => countbox.style = stylesheet,
+                _ => {}
+            };
+
+            self.frame_renderer.write_styled(countbox)?;
+
+            self.frame_renderer.write(" ")?;
+
+            self.print_option_value(idx, option, &page)?;
+
+            self.new_line()?;
+        }
+
+        Ok(())
+    }
+
 }
 
 #[cfg(feature = "date")]


### PR DESCRIPTION
Adds a MultiCount interface. This extends the MultiSelect to allow for (integer) numerical counts. Rather than doing anything complicated, the count is incremented/decremented with the right and left arrows, and incremented/decremented by ten using shift and right, left arrow respectively. I stuck close to the MultiSelect paradigm to minimise the difference from old code in large commits for new features, to make it easier to compare.

If accepted I will add an appropriate README paragraph (it felt rather brash otherwise).  