### PR TITLE
fix: update suggestions list after selecting suggestion from list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+- Fix suggestions not updated after selecting current suggestion.
 
 ## [0.7.5] - 2024-04-23
 

--- a/inquire/examples/complex_autocompletion.rs
+++ b/inquire/examples/complex_autocompletion.rs
@@ -34,7 +34,7 @@ pub struct FilePathCompleter {
 
 impl FilePathCompleter {
     fn update_input(&mut self, input: &str) -> Result<(), CustomUserError> {
-        if input == self.input {
+        if !input.is_empty() && input == self.input {
             return Ok(());
         }
 

--- a/inquire/src/prompts/text/prompt.rs
+++ b/inquire/src/prompts/text/prompt.rs
@@ -214,7 +214,11 @@ where
             TextPromptAction::MoveToSuggestionPageDown => {
                 self.move_cursor_down(self.config.page_size)
             }
-            TextPromptAction::UseCurrentSuggestion => self.use_current_suggestion()?,
+            TextPromptAction::UseCurrentSuggestion => {
+                let result = self.use_current_suggestion()?;
+                self.update_suggestions()?;
+                result
+            }
         };
 
         Ok(result)


### PR DESCRIPTION
Also fix example with file chooser: update suggestions when input is empty, to show suggestions on launch