### PR TITLE
WIP Add with_default for Password

### DIFF
--- a/inquire/src/prompts/password/mod.rs
+++ b/inquire/src/prompts/password/mod.rs
@@ -101,6 +101,9 @@ pub struct Password<'a> {
     /// Function that formats the user input and presents it to the user as the final rendering of the prompt.
     pub formatter: StringFormatter<'a>,
 
+    /// Default value, returned when the user input is empty.
+    pub default: Option<&'a str>,
+
     /// How the password input is displayed to the user.
     pub display_mode: PasswordDisplayMode,
 
@@ -161,12 +164,19 @@ impl<'a> Password<'a> {
             formatter: Self::DEFAULT_FORMATTER,
             validators: Self::DEFAULT_VALIDATORS,
             render_config: get_configuration(),
+            default: None,
         }
     }
 
     /// Sets the help message of the prompt.
     pub fn with_help_message(mut self, message: &'a str) -> Self {
         self.help_message = Some(message);
+        self
+    }
+
+    /// Sets the default input.
+    pub fn with_default(mut self, message: &'a str) -> Self {
+        self.default = Some(message);
         self
     }
 

--- a/inquire/src/prompts/password/prompt.rs
+++ b/inquire/src/prompts/password/prompt.rs
@@ -25,6 +25,7 @@ struct PasswordConfirmation<'a> {
 pub struct PasswordPrompt<'a> {
     message: &'a str,
     config: PasswordConfig,
+    default: Option<&'a str>,
     help_message: Option<&'a str>,
     input: Input,
     current_mode: PasswordDisplayMode,
@@ -51,6 +52,7 @@ impl<'a> From<Password<'a>> for PasswordPrompt<'a> {
         Self {
             message: so.message,
             config: (&so).into(),
+            default: so.default,
             help_message: so.help_message,
             current_mode: so.display_mode,
             confirmation,
@@ -154,6 +156,14 @@ where
 
     fn format_answer(&self, answer: &String) -> String {
         (self.formatter)(answer)
+    }
+
+    fn setup(&mut self) -> InquireResult<()> {
+        if let Some(val) = self.default {
+            self.message = val;
+        }
+
+        Ok(())
     }
 
     fn pre_cancel(&mut self) -> InquireResult<bool> {


### PR DESCRIPTION
It would be nice to be able to create a password prompt with a default password (perhaps sourced from elsewhere). This PR adds a `with_default` function to add this ability.

# Issues

Currently if selecting `PasswordDisplayMode::Masked`, the default password will be shown in full in the render prompt. I'll look into this in the next few days but I'm fairly unfamiliar with the codebase so if any maintainers know the short path to fixing this I'd appreciate some pointers 🙂