### PR TITLE
Fix intra-doc links

### DIFF
--- a/inquire/src/error.rs
+++ b/inquire/src/error.rs
@@ -89,5 +89,5 @@ impl fmt::Display for InquireError {
     }
 }
 
-/// Result type where errors are of type [InquireError](crate::error::InquireError)
+/// Result type where errors are of type [`InquireError`]
 pub type InquireResult<T> = Result<T, InquireError>;

--- a/inquire/src/prompts/multiselect/mod.rs
+++ b/inquire/src/prompts/multiselect/mod.rs
@@ -193,10 +193,10 @@ where
             }
         };
 
-    /// Default page size, equal to the global default page size [config::DEFAULT_PAGE_SIZE]
+    /// Default page size, equal to the global default page size [crate::config::DEFAULT_PAGE_SIZE]
     pub const DEFAULT_PAGE_SIZE: usize = crate::config::DEFAULT_PAGE_SIZE;
 
-    /// Default value of vim mode, equal to the global default value [config::DEFAULT_PAGE_SIZE]
+    /// Default value of vim mode, equal to the global default value [crate::config::DEFAULT_PAGE_SIZE]
     pub const DEFAULT_VIM_MODE: bool = crate::config::DEFAULT_VIM_MODE;
 
     /// Default starting cursor index.

--- a/inquire/src/prompts/one_liners.rs
+++ b/inquire/src/prompts/one_liners.rs
@@ -3,7 +3,7 @@ use crate::{error::InquireResult, Confirm, CustomType, Password, Text};
 /// This function is a helpful one-liner to prompt the user for the confirmation of an action.
 ///
 /// Under the hood, it is equivalent to calling `inquire::Confirm::new(message).prompt()`.
-/// See the documentation for [`inquire::Confirm`] for more information on its behavior.
+/// See the documentation for [`Confirm`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -42,7 +42,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a text input.
 ///
 /// Under the hood, it is equivalent to calling `inquire::Text::new(message).prompt()`.
-/// See the documentation for [`inquire::Text`] for more information on its behavior.
+/// See the documentation for [`Text`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -77,7 +77,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a password, or any secret text.
 ///
 /// Under the hood, it is equivalent to calling `inquire::Password::new(message).prompt()`.
-/// See the documentation for [`inquire::Password`] for more information on its behavior.
+/// See the documentation for [`Password`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -112,7 +112,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a date.
 ///
 /// Under the hood, it is equivalent to calling `inquire::DateSelect::new(message).prompt()`.
-/// See the documentation for [`inquire::DateSelect`] for more information on its behavior.
+/// See the documentation for [`crate::DateSelect`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -148,7 +148,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to f64.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<f64>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -183,7 +183,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to f32.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<f32>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -218,7 +218,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to u64.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<u64>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -253,7 +253,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to u32.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<u32>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -288,7 +288,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to usize.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<usize>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///
@@ -323,7 +323,7 @@ where
 /// This function is a helpful one-liner to prompt the user for a number and parse it to u128.
 ///
 /// Under the hood, it is equivalent to calling `inquire::CustomType::<u128>::new(message).prompt()`.
-/// See the documentation for [`inquire::CustomType`] for more information on its behavior.
+/// See the documentation for [`CustomType`] for more information on its behavior.
 ///
 /// # Arguments
 ///

--- a/inquire/src/prompts/text/mod.rs
+++ b/inquire/src/prompts/text/mod.rs
@@ -126,7 +126,7 @@ impl<'a> Text<'a> {
     /// Default formatter, set to [DEFAULT_STRING_FORMATTER](crate::formatter::DEFAULT_STRING_FORMATTER)
     pub const DEFAULT_FORMATTER: StringFormatter<'a> = DEFAULT_STRING_FORMATTER;
 
-    /// Default page size, equal to the global default page size [config::DEFAULT_PAGE_SIZE]
+    /// Default page size, equal to the global default page size [crate::config::DEFAULT_PAGE_SIZE]
     pub const DEFAULT_PAGE_SIZE: usize = crate::config::DEFAULT_PAGE_SIZE;
 
     /// Default validators added to the [Text] prompt, none.


### PR DESCRIPTION
Several of the links on docs.rs were being rendered as eg [inquire::Confirm]
(here:
[prompt_confirmation](https://docs.rs/inquire/latest/inquire/fn.prompt_confirmation.html)).
