### PR TITLE
Update crossterm to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
+- Upgraded `crossterm` to 0.28.1.
 - Raised minimum supported Rust version to 1.80.0.
 - Migrate functionality from `once_cell` to `stdlib`. Thanks @jarjk for cutting down on a dependency!
 - Migrate functionality from `fxhash` to `stdlib`, as the dependency is no longer maintained. Thanks @ereOn for reporting, and @jarjk for fixing it!

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 crossterm = { version = "0.28.1", optional = true }
-termion = { version = "4.0", optional = true }
+termion = { version = "2.0", optional = true }
 console = { version = "0.15", optional = true, features = [
   "windows-console-colors",
 ] }

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -32,8 +32,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-crossterm = { version = "0.25", optional = true }
-termion = { version = "2.0", optional = true }
+crossterm = { version = "0.28.1", optional = true }
+termion = { version = "4.0", optional = true }
 console = { version = "0.15", optional = true, features = [
   "windows-console-colors",
 ] }
@@ -50,7 +50,7 @@ unicode-segmentation = "1"
 unicode-width = "0.1"
 
 [dev-dependencies]
-rstest = "0.18.2"
+rstest = "0.22.0"
 chrono = { version = "0.4" }
 
 [[example]]

--- a/inquire/src/terminal/crossterm.rs
+++ b/inquire/src/terminal/crossterm.rs
@@ -2,7 +2,7 @@ use std::io::{stderr, Result, Stderr, Write};
 
 use crossterm::{
     cursor,
-    event::{self, KeyCode, KeyEvent, KeyModifiers},
+    event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     queue,
     style::{Attribute, Color, Print, SetAttribute, SetBackgroundColor, SetForegroundColor},
     terminal::{self, ClearType},
@@ -38,7 +38,9 @@ impl InputReader for CrosstermKeyReader {
     fn read_key(&mut self) -> InquireResult<Key> {
         loop {
             if let event::Event::Key(key_event) = event::read()? {
-                return Ok(key_event.into());
+                if KeyEventKind::Press == key_event.kind {
+                    return Ok(key_event.into());
+                }
             }
         }
     }


### PR DESCRIPTION
This updates crossterm to the latest version. When I first did this in my fork I noticed that there was double button presses for everything so I looked into it and fixed the issue so I thought that I would contribute this change back to prevent others from needing to do the same debugging when updating crossterm to the latest version.