### PR TITLE
feat: add an unmasked-last-char display mode for passwords

### DIFF
--- a/KEY_BINDINGS.md
+++ b/KEY_BINDINGS.md
@@ -116,6 +116,13 @@ These key bindings may be used in [`Editor`] prompts.
 | <kbd>enter</kbd> | Submit the current content of the temporary file being edited. |
 
 
+## Password Prompts
+
+These key bindings may be used in [`Password`] prompts.
+
+| **command**                    | **description**                                                                        |
+|--------------------------------|----------------------------------------------------------------------------------------|
+| <kbd>ctrl</kbd> + <kbd>r</kbd> | Toggles between [`Masked`]/[`UnmaskedLastChar`] and [`Full`] (unmasked) display modes. |
 
 
 [`Text`]: https://docs.rs/inquire/*/inquire/prompts/text/struct.Text.html
@@ -126,3 +133,6 @@ These key bindings may be used in [`Editor`] prompts.
 [`Editor`]: https://docs.rs/inquire/*/inquire/prompts/editor/struct.Editor.html
 [`customtype`]: https://docs.rs/inquire/*/inquire/struct.CustomType.html
 [`Password`]: https://docs.rs/inquire/*/inquire/prompts/password/struct.Password.html
+[`Masked`]: https://docs.rs/inquire/latest/inquire/enum.PasswordDisplayMode.html#variant.Masked
+[`UnmaskedLastChar`]: https://docs.rs/inquire/latest/inquire/enum.PasswordDisplayMode.html#variant.UnmaskedLastChar
+[`Full`]: https://docs.rs/inquire/latest/inquire/enum.PasswordDisplayMode.html#variant.Full

--- a/inquire/examples/password_unmasked_last_char.rs
+++ b/inquire/examples/password_unmasked_last_char.rs
@@ -1,0 +1,13 @@
+use inquire::{Password, PasswordDisplayMode};
+
+fn main() {
+    let name = Password::new("RSA Encryption Key:")
+        .with_display_toggle_enabled()
+        .with_display_mode(PasswordDisplayMode::UnmaskedLastChar)
+        .prompt();
+
+    match name {
+        Ok(_) => println!("This doesn't look like a key."),
+        Err(_) => println!("An error happened when asking for your key, try again later."),
+    }
+}

--- a/inquire/src/prompts/password/mod.rs
+++ b/inquire/src/prompts/password/mod.rs
@@ -30,6 +30,10 @@ pub enum PasswordDisplayMode {
     /// render config.
     Masked,
 
+    /// Same as [Masked](PasswordDisplayMode::Masked), but the last typed
+    /// character remains unmasked immediately after typing it.
+    UnmaskedLastChar,
+
     /// Password text input is fully rendered as a normal input, just like
     /// [Text](crate::Text) prompts.
     Full,

--- a/inquire/src/prompts/password/prompt.rs
+++ b/inquire/src/prompts/password/prompt.rs
@@ -5,7 +5,7 @@ use crate::{
     prompts::prompt::{ActionResult, Prompt},
     ui::PasswordBackend,
     validator::{ErrorMessage, StringValidator, Validation},
-    InquireError, Password, PasswordDisplayMode,
+    InputAction, InquireError, Password, PasswordDisplayMode,
 };
 
 use super::{action::PasswordPromptAction, config::PasswordConfig};
@@ -33,6 +33,7 @@ pub struct PasswordPrompt<'a> {
     formatter: StringFormatter<'a>,
     validators: Vec<Box<dyn StringValidator>>,
     error: Option<ErrorMessage>,
+    appending_chars: bool,
 }
 
 impl<'a> From<Password<'a>> for PasswordPrompt<'a> {
@@ -59,6 +60,7 @@ impl<'a> From<Password<'a>> for PasswordPrompt<'a> {
             validators: so.validators,
             input: Input::new(),
             error: None,
+            appending_chars: false,
         }
     }
 }
@@ -82,7 +84,9 @@ impl<'a> PasswordPrompt<'a> {
 
     fn toggle_display_mode(&mut self) -> ActionResult {
         let new_mode = match self.current_mode {
-            PasswordDisplayMode::Hidden | PasswordDisplayMode::Masked => PasswordDisplayMode::Full,
+            PasswordDisplayMode::Hidden
+            | PasswordDisplayMode::Masked
+            | PasswordDisplayMode::UnmaskedLastChar => PasswordDisplayMode::Full,
             PasswordDisplayMode::Full => self.config.display_mode,
         };
 
@@ -196,8 +200,12 @@ where
     }
 
     fn handle(&mut self, action: PasswordPromptAction) -> InquireResult<ActionResult> {
+        self.appending_chars = false;
         let result = match action {
             PasswordPromptAction::ValueInput(input_action) => {
+                if let InputAction::Write(_) = input_action {
+                    self.appending_chars = true;
+                }
                 self.active_input_mut().handle(input_action).into()
             }
             PasswordPromptAction::ToggleDisplayMode => self.toggle_display_mode(),
@@ -233,6 +241,30 @@ where
                         )?;
                     }
                     _ => {}
+                }
+            }
+            PasswordDisplayMode::UnmaskedLastChar => {
+                if self.confirmation_stage || !self.appending_chars {
+                    backend.render_prompt_with_masked_input(self.message, &self.input)?;
+                } else if self.appending_chars {
+                    backend
+                        .render_prompt_with_unmasked_last_char_input(self.message, &self.input)?;
+                }
+
+                if self.confirmation_stage {
+                    if let Some(confirmation) = &self.confirmation {
+                        if self.appending_chars {
+                            backend.render_prompt_with_unmasked_last_char_input(
+                                confirmation.message,
+                                &confirmation.input,
+                            )?;
+                        } else {
+                            backend.render_prompt_with_masked_input(
+                                confirmation.message,
+                                &confirmation.input,
+                            )?;
+                        }
+                    }
                 }
             }
             PasswordDisplayMode::Full => {

--- a/inquire/src/ui/api/render_config.rs
+++ b/inquire/src/ui/api/render_config.rs
@@ -56,7 +56,8 @@ pub struct RenderConfig<'a> {
     pub help_message: StyleSheet,
 
     /// Character used to mask password text inputs when in mode
-    /// [`Masked`](crate::prompts::PasswordDisplayMode).
+    /// [`Masked`](crate::prompts::PasswordDisplayMode::Masked) or
+    /// [`UnmaskedLastChar`](crate::prompts::PasswordDisplayMode::UnmaskedLastChar).
     ///
     /// Note: Styles for masked text inputs are set in the
     /// [`text_input`](crate::ui::RenderConfig::text_input) configuration.

--- a/inquire/src/ui/backend.rs
+++ b/inquire/src/ui/backend.rs
@@ -66,6 +66,11 @@ pub trait CustomTypeBackend: CommonBackend {
 pub trait PasswordBackend: CommonBackend {
     fn render_prompt(&mut self, prompt: &str) -> Result<()>;
     fn render_prompt_with_masked_input(&mut self, prompt: &str, cur_input: &Input) -> Result<()>;
+    fn render_prompt_with_unmasked_last_char_input(
+        &mut self,
+        prompt: &str,
+        cur_input: &Input,
+    ) -> Result<()>;
     fn render_prompt_with_full_input(&mut self, prompt: &str, cur_input: &Input) -> Result<()>;
 }
 
@@ -640,6 +645,21 @@ where
     fn render_prompt_with_masked_input(&mut self, prompt: &str, cur_input: &Input) -> Result<()> {
         let masked_string: String = (0..cur_input.length())
             .map(|_| self.render_config.password_mask)
+            .collect();
+
+        let masked_input = Input::new_with(masked_string).with_cursor(cur_input.cursor());
+
+        self.print_prompt_with_input(prompt, None, &masked_input)
+    }
+
+    fn render_prompt_with_unmasked_last_char_input(
+        &mut self,
+        prompt: &str,
+        cur_input: &Input,
+    ) -> Result<()> {
+        let masked_string: String = (0..cur_input.length().saturating_sub(1))
+            .map(|_| self.render_config.password_mask)
+            .chain(cur_input.content().chars().rev().take(1))
             .collect();
 
         let masked_input = Input::new_with(masked_string).with_cursor(cur_input.cursor());


### PR DESCRIPTION
Adds a new `PasswordDisplayMode` which masks all but the last typed character immediately after being typed.
I also added the missing `KEY_BINDINGS.md` documentation for the password display mode toggle.