### PR TITLE
reintroduce optional auto-display impl via doc comments

### DIFF
--- a/inquire-derive/src/codegen.rs
+++ b/inquire-derive/src/codegen.rs
@@ -1,24 +1,90 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data::Enum, DeriveInput};
+use syn::{Attribute, Data::Enum, DeriveInput, Ident, Lit, Meta};
 
 use crate::utils::enum_name_to_module_name;
 
 pub fn generate_selectable_impl(input: DeriveInput) -> TokenStream {
     let enum_name = &input.ident;
-    let variants = if let Enum(data_enum) = &input.data {
-        data_enum
-            .variants
-            .iter()
-            .map(|v| &v.ident)
-            .collect::<Vec<_>>()
-    } else {
-        panic!("Selectable only supports enums")
+    let (variants, variant_docs): (Vec<&Ident>, Vec<Option<String>>) = {
+        if let Enum(data_enum) = &input.data {
+            let mut variants = Vec::new();
+            let mut docs = Vec::new();
+
+            for variant in data_enum.variants.iter() {
+                let var_ident = &variant.ident;
+                let doc_comment: Option<String> = get_doc_comment(&variant.attrs);
+
+                variants.push(var_ident);
+                docs.push(doc_comment);
+            }
+
+            (variants, docs)
+        } else {
+            panic!("Selectable only supports enums")
+        }
     };
 
+    let has_any_docs = variant_docs.iter().any(|doc| doc.is_some());
     let module_name = enum_name_to_module_name(&enum_name.to_string());
+    let display_impl = if has_any_docs {
+        let match_arms: Vec<proc_macro2::TokenStream> = variants
+            .iter()
+            .zip(variant_docs.iter())
+            .map(|(variant, doc)| {
+                let display_text = doc.as_ref().unwrap_or(&variant.to_string()).clone();
+                quote! {
+                    #enum_name::#variant => write!(f, "{}", #display_text)
+                }
+            })
+            .collect();
+
+        Some(quote! {
+            impl ::std::fmt::Display for #enum_name {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    match self {
+                        #(#match_arms),*
+                    }
+                }
+            }
+        })
+    } else {
+        None
+    };
+
+    let trait_bounds = if has_any_docs {
+        quote! {
+            where
+                Self: ::std::fmt::Debug + Copy + Clone + 'static
+        }
+    } else {
+        quote! {
+            where
+                Self: ::std::fmt::Display + ::std::fmt::Debug + Copy + Clone + 'static
+        }
+    };
+
+    let display_check = if !has_any_docs {
+        quote! {
+            const _: fn() = || {
+                fn assert_display<T: ::std::fmt::Display>() {}
+                assert_display::<#enum_name>();
+            };
+        }
+    } else {
+        quote! {}
+    };
+
+    let variant_array: Vec<proc_macro2::TokenStream> = variants
+        .iter()
+        .map(|variant: &&Ident| {
+            quote! { #enum_name::#variant }
+        })
+        .collect();
 
     let expanded = quote! {
+        #display_impl
+
         mod #module_name {
             use super::*;
 
@@ -28,28 +94,46 @@ pub fn generate_selectable_impl(input: DeriveInput) -> TokenStream {
             }
 
             impl Variants<#enum_name> for #enum_name {
-                const VARIANTS: &'static [#enum_name] = &[#(#enum_name::#variants),*];
+                const VARIANTS: &'static [#enum_name] = &[#(#variant_array),*];
             }
 
             pub use Variants as VariantsTrait;
         }
 
+        #display_check
+
         impl #enum_name {
             pub fn select(msg: &str) -> ::inquire::Select<'_, Self>
-            where
-                Self: ::std::fmt::Display + ::std::fmt::Debug + Copy + Clone + 'static
+            #trait_bounds
             {
-                ::inquire::Select::new(msg, <Self as #module_name::VariantsTrait<Self>>::VARIANTS.to_vec())
+                let variants_vec: Vec<Self> = <Self as #module_name::VariantsTrait<Self>>::VARIANTS.to_vec();
+                ::inquire::Select::new(msg, variants_vec)
             }
 
             pub fn multi_select(msg: &str) -> ::inquire::MultiSelect<'_, Self>
-            where
-                Self: ::std::fmt::Display + ::std::fmt::Debug + Copy + Clone + 'static
+            #trait_bounds
             {
-                ::inquire::MultiSelect::new(msg, <Self as #module_name::VariantsTrait<Self>>::VARIANTS.to_vec())
+                let variants_vec: Vec<Self> = <Self as #module_name::VariantsTrait<Self>>::VARIANTS.to_vec();
+                ::inquire::MultiSelect::new(msg, variants_vec)
             }
         }
     };
 
     TokenStream::from(expanded)
+}
+
+fn get_doc_comment(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if attr.path().is_ident("doc") {
+            if let Meta::NameValue(meta) = &attr.meta {
+                if let syn::Expr::Lit(expr_lit) = &meta.value {
+                    if let Lit::Str(lit_str) = &expr_lit.lit {
+                        return Some(lit_str.value().trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/inquire-derive/src/lib.rs
+++ b/inquire-derive/src/lib.rs
@@ -10,37 +10,80 @@ use syn::{parse_macro_input, DeriveInput};
 /// allowing them to be used directly with inquire's Select and MultiSelect prompts.
 /// The methods return the prompt builders, allowing for further customization.
 ///
-/// The enum must implement `Display`, `Debug`, `Copy`, `Clone`, and be `'static`.
+/// ## Display Implementation
 ///
-/// # Example
+/// The macro automatically implements `Display` for enums **if and only if** any variant
+/// has a doc comment. If doc comments are present on some variants:
+/// - Variants with doc comments use the comment text as their display value
+/// - Variants without doc comments fall back to their variant name
+///
+/// If no variants have doc comments, you must manually implement `Display` before
+/// using the `Selectable` macro, otherwise compilation will fail.
+///
+/// The enum must also implement `Debug`, `Copy`, `Clone`, and be `'static`.
+///
+/// ## Examples
+///
+/// ### With Doc Comments (Auto Display)
 ///
 /// ```ignore
 /// use inquire_derive::Selectable;
-/// use std::fmt::{Display, Formatter};
 ///
 /// #[derive(Debug, Copy, Clone, Selectable)]
 /// enum Color {
+///     /// Bright red color
 ///     Red,
+///     /// Vibrant green color  
 ///     Green,
+///     /// Deep blue color
 ///     Blue,
+///     // This variant will display as "Yellow" (variant name)
+///     Yellow,
 /// }
 ///
-/// impl Display for Color {
-///     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-///         write!(f, "{:?}", self)
+/// // Usage:
+/// let color: Result<Color, inquire::InquireError> = Color::select("Choose a color:").prompt();
+/// ```
+///
+/// ### Without Doc Comments (Manual Display)
+///
+/// ```ignore
+/// use inquire_derive::Selectable;
+/// use std::fmt::{Display, Formatter, Result as FmtResult};
+///
+/// #[derive(Debug, Copy, Clone, Selectable)]
+/// enum Priority {
+///     Low,
+///     Medium,
+///     High,
+/// }
+///
+/// impl Display for Priority {
+///     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+///         let display_str: &str = match self {
+///             Priority::Low => "Low Priority",
+///             Priority::Medium => "Medium Priority",
+///             Priority::High => "High Priority",
+///         };
+///         write!(f, "{}", display_str)
 ///     }
 /// }
 ///
 /// // Usage:
-/// // let color = Color::select("Choose a color:").prompt()?;
-/// //
-/// // With customization:
-/// // let color = Color::select("Choose a color:")
-/// //     .with_help_message("Use arrow keys to navigate")
-/// //     .prompt()?;
-/// //
-/// // Multi-select:
-/// // let colors = Color::multi_select("Choose colors:").prompt()?;
+/// let priority: Result<Priority, inquire::InquireError> = Priority::select("Select priority:").prompt();
+/// ```
+///
+/// ### With Customization
+///
+/// ```ignore
+/// let color: Result<Color, inquire::InquireError> = Color::select("Choose a color:")
+///     .with_help_message("Use arrow keys to navigate")
+///     .with_page_size(5)
+///     .prompt();
+///
+/// let colors: Result<Vec<Color>, inquire::InquireError> = Color::multi_select("Choose multiple colors:")
+///     .with_default(&[Color::Red, Color::Blue])
+///     .prompt();
 /// ```
 #[proc_macro_derive(Selectable, attributes(desc))]
 pub fn derive_selectable(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
having a doc comment on any variant will result in `Display` being auto-implemented
having no doc comments on any variant introduces the requirement of manually implementing display