### PR TITLE
confirm: add `confirm_on_input` for immediate y/n confirmation

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,6 +67,10 @@ name = "confirm"
 path = "confirm.rs"
 
 [[example]]
+name = "confirm_on_input"
+path = "confirm_on_input.rs"
+
+[[example]]
 name = "custom_type"
 path = "custom_type.rs"
 

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -35,6 +35,7 @@ fn main() {
             true => String::from("sim"),
             false => String::from("não"),
         },
+        confirm_on_input: false,
         render_config: RenderConfig::default(),
     }
     .prompt()

--- a/examples/confirm_on_input.rs
+++ b/examples/confirm_on_input.rs
@@ -1,0 +1,28 @@
+use inquire::Confirm;
+
+fn main() {
+    println!("Standard confirm prompt (requires Enter after y/n):");
+    let standard = Confirm::new("Do you want to continue?")
+        .with_default(true)
+        .prompt();
+
+    match standard {
+        Ok(true) => println!("You chose to continue!\n"),
+        Ok(false) => println!("You chose not to continue!\n"),
+        Err(_) => println!("Error occurred!\n"),
+    }
+
+    println!("Confirm with immediate input (y/n submits immediately):");
+    let immediate = Confirm::new("Are you sure you want to delete this file?")
+        .with_default(false)
+        .with_confirm_on_input(true)
+        .prompt();
+
+    match immediate {
+        Ok(true) => println!("File will be deleted!"),
+        Ok(false) => println!("File deletion cancelled."),
+        Err(_) => println!("Error occurred!"),
+    }
+
+    println!("\nTip: In the second prompt, just press 'y' or 'n' - no Enter needed!");
+}


### PR DESCRIPTION
This MR adds a new "confirm on input" feature to the `Confirm` prompt that allows users to submit immediately on 'y' or 'n' input without needing to hit Enter. This can be considered an alternative for less "severe" prompts where immediate responses do not yield destructive results.

The motivation for this PR comes from <https://github.com/nix-community/nh/issues/420>; the previous prompt library confirmed immediately and while I love inquire's design more, I'd like to retain backwards compatibility to avoid confusing users. This is backwards compatible with prior implementation. I've also went ahead and add a test for this change, hope it is satisfactory.


Change-Id: I6a6a6964443d7a87bee6f9e9ca2456b68a160df0