### PR TITLE
Place cursor after prompt text in hidden mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+### Fixes
+
+- Fix the cursor placement of `Password` prompts using the `Hidden` display mode: the cursor is now placed right after the prompt text.
 
 ## [0.9.4] - 2026-02-24
 

--- a/inquire/src/ui/backend.rs
+++ b/inquire/src/ui/backend.rs
@@ -639,6 +639,7 @@ where
 {
     fn render_prompt(&mut self, prompt: &str) -> Result<()> {
         self.print_prompt(prompt)?;
+        self.frame_renderer.mark_cursor_position(0);
         self.new_line()?;
         Ok(())
     }


### PR DESCRIPTION
The hidden password prompt never marked a cursor position for the
frame renderer, leaving the terminal cursor at column 0 of the last
rendered row, on the prompt prefix or the help message line.

Fixes: https://github.com/mikaelmello/inquire/issues/348
